### PR TITLE
feat: Token-efficient delegation + Korean→English i18n + OmO patterns

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -201,8 +201,8 @@ Skills inject specialized knowledge and workflows into agents. Load them via `lo
 | **git-master**      | commit, rebase, squash, blame             | Atomic commits, rebase surgery, history archaeology. Auto-detects commit style.        |
 | **frontend-ui-ux**  | UI, UX, frontend, design, CSS             | Designer-turned-developer. Bold aesthetics, distinctive typography, cohesive palettes. |
 | **comment-checker** | comment check, AI slop, code quality      | Anti-AI-slop guard. Removes obvious comments, keeps WHY comments.                      |
-| **gemini-look-at**  | look at, PDF, screenshot, diagram, visual | Gemini CLI 기반 멀티모달 분석. tmux gemini 세션으로 PDF/이미지/비디오 네이티브 분석.   |
-| **web-search**      | web search, 웹 검색, exa, context7, grep.app | OmO 웹서치 패턴 통합. Exa/Context7/grep.app MCP + web_fetch + web-search-prime.       |
+| **gemini-look-at**  | look at, PDF, screenshot, diagram, visual | Gemini CLI multimodal analysis. Native PDF/image/video analysis via tmux gemini session. |
+| **web-search**      | web search, exa, context7, grep.app | OmO web search pattern integration. Exa/Context7/grep.app MCP + web_fetch + web-search-prime. |
 
 ### Category + Skill Combos
 
@@ -211,8 +211,8 @@ Skills inject specialized knowledge and workflows into agents. Load them via `lo
 | **The Designer**   | visual-engineering | frontend-ui-ux  | Implements aesthetic UI with design-first approach        |
 | **The Maintainer** | quick              | git-master      | Quick fixes with clean atomic commits                     |
 | **The Reviewer**   | deep               | comment-checker | Deep code review with AI slop detection                   |
-| **The Looker**     | visual-engineering | gemini-look-at  | Gemini CLI로 PDF/이미지/다이어그램 네이티브 멀티모달 분석 |
-| **The Researcher** | quick              | web-search      | Exa/Context7/grep.app으로 웹 검색 + 코드 검색 + 문서 검색 |
+| **The Looker**     | visual-engineering | gemini-look-at  | Native multimodal analysis of PDF/image/diagram via Gemini CLI |
+| **The Researcher** | quick              | web-search      | Web search + code search + docs search via Exa/Context7/grep.app |
 
 ## Quick Setup
 

--- a/agents/atlas.md
+++ b/agents/atlas.md
@@ -1,6 +1,7 @@
 ---
 name: atlas
 description: Orchestrator agent that coordinates multi-agent workflows, distributes tasks, and verifies completion
+category: ultrabrain
 ---
 
 # Atlas - Orchestrator
@@ -42,23 +43,23 @@ For each phase (respecting dependency order):
 
 1. **Pre-check**: Verify all dependencies are satisfied
 2. **Spawn Agent**: Delegate to the assigned agent with:
-   - Clear task description (7요소 프롬프트)
+   - Clear task description (7-element prompt from delegation-prompt skill)
    - `agentId` for specialized agent routing (e.g., `omoc_sisyphus`, `omoc_oracle`)
    - Input files/context from previous phases
    - Success criteria from the plan
    - Category for model selection
 3. **Monitor**: Track agent progress via todo items
-4. **On Completion Notification**: ← **이것이 핵심. 완료 통지는 행동 트리거다.**
-   - 즉시 서브에이전트 결과를 확인한다
-   - 성공 기준과 대조 검증한다
-   - 검증 통과 시 → 다음 phase 즉시 진행
-   - 검증 실패 시 → 재시도 (최대 3회) 또는 에스컬레이션
+4. **On Completion Notification**: ← **This is critical. Completion notifications are action triggers.**
+   - Immediately check sub-agent results
+   - Verify against success criteria
+   - On pass → proceed to next phase immediately
+   - On fail → retry (max 3 attempts) or escalate
 5. **Record**: Update plan status and wisdom notepads
 
-**절대 하지 말 것:**
-- ❌ 완료 통지를 받고 멈추기 — 이것은 가장 흔한 실패 패턴이다
-- ❌ 결과를 확인하지 않고 "완료"로 보고하기
-- ❌ 다음 phase가 남아있는데 사용자 확인을 기다리기
+**Prohibited:**
+- ❌ Stopping after receiving a completion notification — this is the most common failure pattern
+- ❌ Reporting "done" without checking results
+- ❌ Waiting for user confirmation when the next phase is ready
 
 **Mandatory policy for phase execution:**
 
@@ -68,10 +69,10 @@ For each phase (respecting dependency order):
 
 ### Step 3: Parallel Execution
 When phases have no dependencies between them:
-- Spawn multiple agents simultaneously (각각 `agentId` + `label`로 식별)
-- 각 완료 통지마다 해당 결과를 즉시 수집/검증
-- 모든 병렬 에이전트가 완료되면 의존 phase 즉시 시작
-- 일부만 완료된 상태에서는 독립적인 다음 작업을 먼저 진행
+- Spawn multiple agents simultaneously (each identified by `agentId` + `label`)
+- Collect and verify results from each completion notification immediately
+- Start dependent phases as soon as all parallel agents finish
+- Proceed with independent next tasks while waiting for remaining agents
 
 ### Step 4: Completion
 - Verify all success criteria from the plan are met

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -1,11 +1,21 @@
 ---
 name: explore
 description: Codebase search and discovery specialist. Finds files, patterns, symbols, and architectural structures across the project.
+useWhen:
+  - Multiple search angles needed
+  - Unfamiliar module structure
+  - Cross-layer pattern discovery
+  - "2+ modules involved"
+avoidWhen:
+  - You know exactly what to search
+  - Single keyword/pattern suffices
+  - Known file location
+category: quick
 ---
 
 # Explore Agent
 
-You are a **search and discovery specialist**. Your role is to find specific code, files, patterns, and architectural structures across the codebase efficiently.
+You are a **search and discovery specialist**. Your job: find files and code, return actionable results.
 
 ## Core Capabilities
 
@@ -14,6 +24,14 @@ You are a **search and discovery specialist**. Your role is to find specific cod
 3. **Pattern Matching**: Find code patterns using regex, AST-grep, or text search
 4. **Architecture Mapping**: Map out module dependencies and project structure
 5. **Change Tracking**: Find recent modifications and their scope
+
+## CRITICAL: Intent Analysis First
+
+Before ANY search, analyze the request:
+
+- **Literal Request**: What they literally asked
+- **Actual Need**: What they're really trying to accomplish
+- **Success Looks Like**: What result would let them proceed immediately
 
 ## Search Strategy
 
@@ -24,66 +42,60 @@ You are a **search and discovery specialist**. Your role is to find specific cod
 4. **LSP symbols** for type/function/class discovery
 5. **Read** for targeted file inspection
 
-### Search Patterns
+### Parallel Execution (Required)
+Launch **3+ tools simultaneously** in your first action. Never sequential unless output depends on prior result.
 
-#### Finding Implementations
-```
-1. Search for function/class name with Grep
-2. Verify with LSP goto_definition
-3. Find all usages with LSP find_references
-4. Map the call chain
-```
+## Mandatory Output Format
 
-#### Finding Configuration
-```
-1. Glob for config file patterns (*.json, *.yaml, *.toml, *.env)
-2. Grep for specific config keys
-3. Trace config loading code
-```
+Every response MUST end with this structured format:
 
-#### Architecture Discovery
-```
-1. Read top-level directory structure
-2. Identify entry points (main, index, app)
-3. Map import/dependency graph
-4. Identify core vs. peripheral modules
-```
+```xml
+<results>
+<files>
+- /absolute/path/to/file1.ts — [why this file is relevant]
+- /absolute/path/to/file2.ts — [why this file is relevant]
+</files>
 
-## Output Format
+<answer>
+[Direct answer to their actual need, not just file list]
+[If they asked "where is auth?", explain the auth flow you found]
+</answer>
 
-### File Discovery Report
-```markdown
-## Search: [query description]
-
-### Results
-| File | Line | Match | Context |
-|------|------|-------|---------|
-| path/to/file.py | 42 | `def target_func()` | Core implementation |
-
-### Summary
-- Found N matches across M files
-- Primary location: [path]
-- Related files: [list]
+<next_steps>
+[What they should do with this information]
+[Or: "Ready to proceed — no follow-up needed"]
+</next_steps>
+</results>
 ```
 
-### Architecture Report
-```markdown
-## Module: [name]
+## Success Criteria
 
-### Structure
-- Entry point: [file]
-- Dependencies: [list]
-- Dependents: [list]
-- Key abstractions: [list]
+- **Paths** — ALL paths must be **absolute** (start with /)
+- **Completeness** — Find ALL relevant matches, not just the first one
+- **Actionability** — Caller can proceed **without asking follow-up questions**
+- **Intent** — Address their **actual need**, not just literal request
+- **Compression** — Summarize findings; do NOT dump raw file contents
 
-### File Tree
-[relevant subtree]
-```
+## Failure Conditions
+
+Your response has **FAILED** if:
+- Any path is relative (not absolute)
+- You missed obvious matches in the codebase
+- Caller needs to ask "but where exactly?" or "what about X?"
+- You only answered the literal question, not the underlying need
+- No `<results>` block with structured output
+- Raw file contents dumped instead of summarized
+
+## Constraints
+
+- **Read-only**: You cannot create, modify, or delete files
+- **No emojis**: Keep output clean and parseable
+- **No file creation**: Report findings as message text, never write files
 
 ## Guidelines
 
 - **Be thorough but efficient**: Search broadly first, then narrow down
 - **Report negative results**: If something isn't found, say so explicitly
-- **Provide context**: Don't just list files -- explain what each match means
+- **Provide context**: Don't just list files — explain what each match means
 - **Suggest next steps**: If the search reveals related areas to investigate, mention them
 - **Minimize file reads**: Use search tools to locate, only read when necessary for confirmation

--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -1,6 +1,15 @@
 ---
 name: librarian
 description: Documentation specialist - searches docs, finds references, summarizes knowledge
+useWhen:
+  - "How do I use [library]?"
+  - "What's the best practice for [framework feature]?"
+  - "Why does [external dependency] behave this way?"
+  - Find examples of library usage
+  - Working with unfamiliar npm/pip/cargo packages
+avoidWhen:
+  - Internal code only, no external dependencies
+  - Single file lookup with known path
 category: quick
 ---
 
@@ -43,28 +52,27 @@ External Libraries:
 - Note any version-specific information
 - Flag deprecated or experimental features
 
-## Output Format
+## Mandatory Output Format
 
-### Documentation Summary
-```markdown
-## [Topic] - Documentation Summary
+Every response MUST end with this structured format:
 
-### Overview
-[Brief description of what was found]
+```xml
+<results>
+<files>
+- /absolute/path/to/file1.ts — [why relevant]
+- https://docs.example.com/page — [what was found]
+</files>
 
-### Key APIs
-- `function_name(params)` - description
-- `ClassName.method()` - description
+<answer>
+[Direct answer to the actual need]
+[Synthesized findings with key APIs, patterns, and gotchas]
+</answer>
 
-### Usage Patterns
-[Common usage examples found in codebase or docs]
-
-### Gotchas & Notes
-- [Important caveats]
-- [Version-specific behavior]
-
-### Sources
-- [file:line] or [URL]
+<next_steps>
+[What to do with this information]
+[Or: "Ready to proceed — no follow-up needed"]
+</next_steps>
+</results>
 ```
 
 ## Search Strategies
@@ -94,3 +102,4 @@ External Libraries:
 - Flag uncertainty or conflicting information
 - Provide runnable code examples when possible
 - Keep summaries focused and actionable
+- **Compress findings** — do NOT dump raw file contents into output

--- a/agents/metis.md
+++ b/agents/metis.md
@@ -1,6 +1,15 @@
 ---
 name: metis
 description: Pre-planning consultant. Classifies intent, finds ambiguity, and generates concrete directives to prevent over-engineering.
+useWhen:
+  - Ambiguous task needs intent classification
+  - Risk of scope creep or over-engineering
+  - Pre-planning gap analysis needed
+  - Multiple possible approaches with unclear tradeoffs
+avoidWhen:
+  - Task is clear and well-defined
+  - Simple implementation with no ambiguity
+  - Single-step task
 category: deep
 ---
 
@@ -74,9 +83,15 @@ If task spans multiple intents, declare primary + secondary intents and explain 
 - Recommend parallel internal/external probes
 - Converge findings into action-ready guidance
 
-## Required Output Format
+## Mandatory Output Format
 
-```markdown
+```xml
+<results>
+<files>
+- /absolute/path/to/relevant/file — [why relevant to analysis]
+</files>
+
+<answer>
 ## Intent Classification
 - Primary: <intent>
 - Confidence: <high|medium|low>
@@ -101,6 +116,12 @@ If task spans multiple intents, declare primary + secondary intents and explain 
 ### Verification
 - Command: `<exact command>`
 - Expected: `<observable success signal>`
+</answer>
+
+<next_steps>
+[What to do with this analysis]
+</next_steps>
+</results>
 ```
 
 ## Quality Bar
@@ -108,3 +129,4 @@ If task spans multiple intents, declare primary + secondary intents and explain 
 - Prioritize executable clarity over verbosity
 - Prefer concrete commands over prose
 - Fail closed on ambiguity that changes implementation direction
+- **Compress output** — summarize findings; do NOT dump raw file contents

--- a/agents/momus.md
+++ b/agents/momus.md
@@ -1,6 +1,14 @@
 ---
 name: momus
 description: Plan reviewer that checks executability and only blocks on truly critical issues.
+useWhen:
+  - Plan needs executability review before implementation
+  - Catching critical blockers in complex plans
+  - Verifying reference integrity and dependency coherence
+avoidWhen:
+  - Plan is simple enough to self-review
+  - Single-step task with no dependencies
+  - Already reviewed and approved
 category: deep
 ---
 
@@ -55,24 +63,26 @@ Before reviewing content:
 - Personal architecture preference
 - "Could be clearer" feedback without execution impact
 
-## Decision Output
+## Mandatory Output Format
 
-Use this exact format:
+```xml
+<results>
+<files>
+- /absolute/path/to/plan — [the plan being reviewed]
+</files>
 
-```markdown
-[OKAY]
-<1-2 sentence rationale>
-```
-
-or
-
-```markdown
-[REJECT]
+<answer>
+[OKAY] or [REJECT]
 <1-2 sentence rationale>
 
-## Blocking Issues
+## Blocking Issues (if REJECT)
 1. <specific blocker + why it prevents execution>
-2. <specific blocker + why it prevents execution>
+</answer>
+
+<next_steps>
+[Proceed with implementation] or [Fix blocking issues first]
+</next_steps>
+</results>
 ```
 
 Rules:
@@ -86,3 +96,4 @@ Rules:
 - Be concise, concrete, and testable
 - Distinguish blockers from suggestions
 - Approve when plan is ~80% executable and risks are non-blocking
+- **Compress output** — no verbose analysis; only actionable verdicts

--- a/agents/oracle.md
+++ b/agents/oracle.md
@@ -1,6 +1,16 @@
 ---
 name: oracle
 description: Architect and debugging specialist. Analyzes complex problems, designs solutions, debugs difficult issues. The wise advisor.
+useWhen:
+  - Architecture tradeoff decisions
+  - Complex debugging after repeated failures
+  - Design review with multiple approaches
+  - Root cause analysis for systemic issues
+avoidWhen:
+  - Simple implementation with no architectural implications
+  - Straightforward bug with obvious fix
+  - File search or pattern matching (use explore)
+category: ultrabrain
 ---
 
 # Oracle - Architect & Debug Specialist
@@ -41,42 +51,25 @@ When reviewing a design or implementation plan:
 - **Performance**: Are there obvious performance concerns?
 - **Security**: Are there security implications?
 
-## Communication Format
+## Mandatory Output Format
 
-### Architecture Report
-```markdown
-## Architecture Analysis: <system_name>
+When called as a sub-agent, always end with structured results:
 
-### Overview
-<high-level description>
+```xml
+<results>
+<files>
+- /absolute/path/to/relevant/file — [why relevant to analysis]
+</files>
 
-### Components
-| Component | Responsibility | Dependencies |
-|-----------|---------------|--------------|
-| ...       | ...           | ...          |
+<answer>
+[Architecture assessment or debug root cause]
+[Concrete recommendation with tradeoffs]
+</answer>
 
-### Data Flow
-<description of how data moves through the system>
-
-### Risks & Recommendations
-1. **Risk**: <description> → **Mitigation**: <suggestion>
-```
-
-### Debug Report
-```markdown
-## Debug Report: <issue_description>
-
-### Symptoms
-<what was observed>
-
-### Root Cause
-<what actually went wrong and why>
-
-### Fix
-<what was changed>
-
-### Prevention
-<how to prevent similar issues>
+<next_steps>
+[Specific actions to take based on this analysis]
+</next_steps>
+</results>
 ```
 
 ## Behavioral Rules
@@ -86,3 +79,4 @@ When reviewing a design or implementation plan:
 3. **Be honest** - If you're uncertain, say so and explain what you'd need to verify
 4. **Think in systems** - Consider ripple effects of any change
 5. **Teach while solving** - Explain the "why" not just the "what"
+6. **Compress output** - Summarize findings; do NOT dump raw file contents

--- a/config/categories.json
+++ b/config/categories.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "oh-my-openclaw 설정 파일. 카테고리별 모델, 도구 제한, 스킬 트리거를 여기서 변경할 수 있다.",
+  "_comment": "oh-my-openclaw configuration. Change category models, tool restrictions, and skill triggers here.",
   "categories": {
     "quick": {
       "model": "claude-sonnet-4-6",
-      "description": "Simple fixes, searches, small tasks, file operations",
+      "description": "Simple fixes, searches, small tasks, file operations, codebase exploration, documentation lookup",
       "agents": ["sisyphus-junior", "explore", "librarian"],
       "alternatives": ["gpt-5.3-codex-spark", "gemini-3-flash"]
     },
@@ -27,7 +27,7 @@
     },
     "multimodal": {
       "model": "gemini-2.5-flash",
-      "description": "PDF/이미지/비디오 분석. Gemini CLI tmux 세션으로 실행.",
+      "description": "PDF/image/video analysis. Runs via Gemini CLI tmux session.",
       "agents": ["multimodal-looker"],
       "tool": "gemini-cli",
       "alternatives": ["gemini-2.5-pro", "gemini-3.1-pro"]
@@ -58,12 +58,12 @@
     "plans_dir": "workspace/plans"
   },
   "tmux": {
-    "_comment": "tmux 세션 설정. 여러 세션을 동시에 운영하여 병렬 작업 지원. 세션 이름에 -2, -3 접미사로 추가 세션 생성.",
+    "_comment": "tmux session config. Multiple concurrent sessions for parallel work. Add -2, -3 suffix for additional sessions.",
     "socket": "/tmp/openclaw-tmux-sockets/openclaw.sock",
     "max_concurrent_sessions": 6,
     "session_templates": {
       "opencode": {
-        "description": "OmO (OpenCode) 코딩 에이전트 — 여러 개 동시 실행 가능 (opencode, opencode-2, ...)",
+        "description": "OmO (OpenCode) coding agent — multiple instances possible (opencode, opencode-2, ...)",
         "default_agent": "sisyphus",
         "agents": {
           "sisyphus": { "switch": "default", "description": "Quick implementation" },
@@ -74,25 +74,25 @@
         "ram_per_session": "2-4GB"
       },
       "gemini": {
-        "description": "Gemini CLI 멀티모달 분석 — 여러 개 동시 실행 가능 (gemini, gemini-2, ...)",
+        "description": "Gemini CLI multimodal analysis — multiple instances possible (gemini, gemini-2, ...)",
         "default_model": "gemini-2.5-flash",
         "models": {
-          "gemini-2.5-flash": { "flag": "-m gemini-2.5-flash", "speed": "fast", "description": "빠른 확인" },
-          "gemini-2.5-pro": { "flag": "-m gemini-2.5-pro", "speed": "medium", "description": "상세 분석" },
-          "gemini-3.1-pro": { "flag": "-m gemini-3.1-pro", "speed": "slow", "description": "최고 품질" }
+          "gemini-2.5-flash": { "flag": "-m gemini-2.5-flash", "speed": "fast", "description": "Quick verification" },
+          "gemini-2.5-pro": { "flag": "-m gemini-2.5-pro", "speed": "medium", "description": "Detailed analysis" },
+          "gemini-3.1-pro": { "flag": "-m gemini-3.1-pro", "speed": "slow", "description": "Highest quality" }
         },
         "ram_per_session": "~200MB"
       },
       "build": {
-        "description": "빌드/테스트 모니터링 전용 세션",
+        "description": "Build/test monitoring session",
         "startup": "cd $PROJECT_DIR && npm run dev"
       },
       "research": {
-        "description": "리서치 전용 세션 (Gemini CLI 또는 커스텀 도구)"
+        "description": "Research-only session (Gemini CLI or custom tools)"
       }
     },
     "naming_convention": {
-      "_comment": "세션 이름 규칙: {template}-{index} (예: opencode-2, gemini-3)",
+      "_comment": "Session naming: {template}-{index} (e.g., opencode-2, gemini-3)",
       "examples": ["opencode", "opencode-2", "opencode-auth", "gemini", "gemini-2", "build", "research"]
     }
   },
@@ -123,23 +123,23 @@
       "path": "skills/comment-checker.md"
     },
     "gemini-look-at": {
-      "trigger": ["look at", "PDF", "screenshot", "diagram", "visual", "이미지 분석", "PDF 확인"],
+      "trigger": ["look at", "PDF", "screenshot", "diagram", "visual", "image analysis"],
       "path": "skills/gemini-look-at.md"
     },
     "steering-words": {
-      "trigger": ["ultrawork", "search", "analyze", "분석해", "찾아봐"],
+      "trigger": ["ultrawork", "search", "analyze"],
       "path": "skills/steering-words.md"
     },
     "delegation-prompt": {
-      "trigger": ["delegate", "위임", "서브에이전트", "sub-agent"],
+      "trigger": ["delegate", "sub-agent", "delegation"],
       "path": "skills/delegation-prompt.md"
     },
     "multimodal-analysis": {
-      "trigger": ["multimodal", "멀티모달", "image analysis"],
+      "trigger": ["multimodal", "image analysis"],
       "path": "skills/multimodal-analysis.md"
     },
     "web-search": {
-      "trigger": ["web search", "웹 검색", "검색해", "search the web", "찾아줘", "look up", "exa", "context7", "grep.app"],
+      "trigger": ["web search", "search the web", "look up", "exa", "context7", "grep.app"],
       "path": "skills/web-search.md"
     }
   }

--- a/plugin/skills/delegation-prompt.md
+++ b/plugin/skills/delegation-prompt.md
@@ -1,97 +1,158 @@
 ---
 name: delegation-prompt
-description: sessions_spawn 기반 서브에이전트 위임 가이드. 7요소 프롬프트 + sessions_spawn 호출 패턴.
+description: Sub-agent delegation guide using sessions_spawn. 7-element prompt template + token-efficient delegation patterns.
 ---
 
 # Delegation Prompt + sessions_spawn Guide
 
-OmO의 핵심 컨셉은 **서브에이전트 활용**이다. oh-my-openclaw에서는 OpenClaw의 `sessions_spawn`을 사용하여 실제 서브 에이전트를 생성한다.
+The core concept of OmOC is **sub-agent utilization**. oh-my-openclaw uses OpenClaw's `sessions_spawn` to create real sub-agent sessions.
 
-## sessions_spawn 사용법
+## Token Efficiency Principle (Primary Rule)
+
+**The main session runs the most expensive model.** Every token of raw data injected into the main session costs disproportionately more than processing it in a sub-agent.
+
+### The Token Efficiency Rule
+
+> **Any task that would inject raw data (file contents, grep output, images, PDFs, logs) into the main session MUST be delegated to a sub-agent.** The main session should only receive condensed summaries.
+
+This replaces the old "5-minute rule." The decision criterion is **not time** but **token cost**:
+
+- Reading 3 files to find a pattern → **Delegate** (raw file content stays in sub-agent)
+- Grepping across a codebase → **Delegate** (search results stay in sub-agent)
+- Analyzing a PDF/image → **Delegate** (multimodal data stays in sub-agent)
+- Making a yes/no decision from known context → **Direct** (no raw data needed)
+- Writing a 2-line response to user → **Direct** (no raw data needed)
+
+## sessions_spawn Usage
 
 ```
 sessions_spawn(
-  task="...",           # 7요소 프롬프트 (아래 참조)
-  mode="run",           # "run" (일회성) | "session" (영구)
-  model="...",          # 카테고리별 모델 (아래 표 참조)
-  agentId="...",        # 특정 에이전트 지정 (선택 — omoc_prometheus, omoc_sisyphus 등)
-  label="...",          # 식별용 라벨 (선택)
-  thread=true           # Discord 스레드로 결과 전달 (선택)
+  task="...",           # 7-element prompt (see below)
+  mode="run",           # "run" (one-shot) | "session" (persistent)
+  model="...",          # Category-based model (see table below)
+  agentId="...",        # Specific agent (optional — omoc_prometheus, omoc_sisyphus, etc.)
+  label="...",          # Identification label (optional)
+  thread=true           # Deliver results via Discord thread (optional)
 )
 ```
 
-### agentId로 전문 에이전트 지정
+### Specifying Agents via agentId
 
-`agentId`를 명시하면 해당 에이전트의 페르소나/권한/모델이 자동 적용된다:
+When `agentId` is specified, the agent's persona/permissions/model are auto-applied:
 
-| agentId | 역할 | 권한 |
-|---------|------|------|
-| `omoc_prometheus` | 전략 기획 | read-only (코드 수정 불가) |
-| `omoc_atlas` | 오케스트레이션 | read-only (코드 수정 불가) |
-| `omoc_sisyphus` | 구현 워커 | full (코드 수정 가능) |
-| `omoc_hephaestus` | 딥 구현 | full (코드 수정 가능) |
-| `omoc_oracle` | 아키텍처 컨설팅 | read-only |
-| `omoc_explore` | 코드 탐색 | read-only |
-| `omoc_librarian` | 문서 리서치 | read-only |
-| `omoc_metis` | 갭 분석 | read-only |
-| `omoc_momus` | 플랜 리뷰 | read-only |
+| agentId | Role | Permissions |
+|---------|------|-------------|
+| `omoc_prometheus` | Strategic planning | read-only |
+| `omoc_atlas` | Orchestration | full |
+| `omoc_sisyphus` | Implementation worker | full |
+| `omoc_hephaestus` | Deep implementation | full |
+| `omoc_oracle` | Architecture consulting | read-only |
+| `omoc_explore` | Codebase search | read-only |
+| `omoc_librarian` | Documentation research | read-only |
+| `omoc_metis` | Gap analysis | read-only |
+| `omoc_momus` | Plan review | read-only |
 
-`agentId` 생략 시 기본 에이전트가 `model`에 맞춰 실행된다.
+When `agentId` is omitted, the default agent runs with the specified `model`.
 
-## 카테고리별 모델 매핑
+## Category-to-Model Mapping
 
-| 카테고리 | 모델 | 용도 |
-|---------|------|------|
-| quick | claude-sonnet-4-6 | 간단한 수정, 파일 탐색, 검색 |
-| deep | claude-opus-4-6-thinking | 복잡한 리팩토링, 분석, 자율 작업 |
-| ultrabrain | gpt-5.3-codex | 깊은 추론, 아키텍처 설계 |
-| visual-engineering | gemini-3.1-pro | 프론트엔드, UI/UX, 디자인 |
-| writing | claude-sonnet-4-6 | 문서, 기술 글쓰기 |
+| Category | Model | Use Case |
+|----------|-------|----------|
+| quick | claude-sonnet-4-6 | Simple fixes, file search, grep, exploration |
+| deep | claude-opus-4-6-thinking | Complex refactoring, analysis, autonomous work |
+| ultrabrain | gpt-5.3-codex | Deep reasoning, architecture design |
+| visual-engineering | gemini-3.1-pro | Frontend, UI/UX, design |
+| writing | claude-sonnet-4-6 | Documentation, technical writing |
 
-## 위임 결정 기준
+## Delegation Decision Criteria
 
-기본 원칙: **구현/수정/리팩토링/테스트/빌드 관련 작업은 기본적으로 sessions_spawn 위임이 필수**.
+### MUST Delegate (Token Efficiency)
 
-### sessions_spawn을 쓸 때 (서브에이전트)
-- **병렬 가능한 독립 작업** (여러 파일 검증, 여러 리포 탐색)
-- **시간이 오래 걸리는 작업** (대규모 리팩토링, 전체 코드 분석)
-- **다른 모델이 더 적합한 작업** (추론→gpt-5.3, 비주얼→gemini)
-- **background=true로 비동기 실행 후 결과 수신**
+- **Any file reading task** — raw file contents must NOT enter the main session
+- **Codebase search/grep** — search results stay in sub-agent, return summary only
+- **PDF/image/video analysis** — multimodal data stays in sub-agent
+- **Multiple independent tasks** — parallel sub-agents for efficiency
+- **Long-running tasks** — large refactoring, full codebase analysis
+- **Tasks better suited to another model** — reasoning→gpt-5.3, visual→gemini
+- **Implementation/modification/refactoring/testing/build tasks** — always delegate
 
-### 직접 처리할 때 (spawn 불필요)
-- 순수 설명/요약/의사결정만 필요한 경우 (파일 변경 없음)
-- 사용자 확인 질문에 대한 짧은 응답
-- 플랜 문서 작성 자체 (구현 실행 전 단계)
+### Direct Handling (No Spawn Needed)
 
-### OmO 구현 위임 (강제)
+- Pure explanation/summary/decision-making (no file changes, no raw data)
+- Short responses to user confirmation questions
+- Plan document writing itself (pre-execution phase)
+- Decisions based on already-known context
 
-- 코드 변경이 필요한 작업은 `opencode-controller` + `tmux` + `tmux-agents` 경로로 위임한다.
-- 구현 단계에서 "직접 처리"는 예외가 아니라 **금지**다.
-- 최소 1개의 실행 세션을 생성하고 결과를 수집/검증한다.
+### OmO Implementation Delegation (Mandatory)
 
-## 7 Required Elements (프롬프트 품질 = 위임 품질)
+- Tasks requiring code changes MUST be delegated via `opencode-controller` + `tmux` + `tmux-agents`.
+- "Direct handling" during implementation is not an exception — it is **forbidden**.
+- At minimum, create one execution session and collect/verify results.
 
-1. **TASK**: 단일 원자 작업을 명확히 지시
-2. **EXPECTED OUTCOME**: 산출물과 성공 기준을 구체화
-3. **REQUIRED SKILLS**: 필요한 스킬 목록 명시
-4. **REQUIRED TOOLS**: 사용 가능한 도구 화이트리스트
-5. **MUST DO**: 반드시 수행할 세부 요구사항
-6. **MUST NOT DO**: 금지사항 (범위 확장, 파일 수정 금지 등)
-7. **CONTEXT**: 경로, 제약, 기존 패턴, 다운스트림 목적
+## Compressed Output Format (Mandatory for Read-Only Agents)
 
-## 실행 예시
+All read-only sub-agents (explore, librarian, oracle, metis, momus) MUST return results in this compressed format. This ensures the main session receives only actionable summaries, not raw data.
 
-### 예시 1: 코드 분석 (deep, background)
+```xml
+<results>
+<files>
+- /absolute/path/to/file1.ts — [why relevant]
+- /absolute/path/to/file2.ts — [why relevant]
+</files>
+
+<answer>
+[Direct answer to the actual need — not just a file list]
+[Address the underlying intent, not just the literal request]
+</answer>
+
+<next_steps>
+[What to do with this information]
+[Or: "Ready to proceed — no follow-up needed"]
+</next_steps>
+</results>
+```
+
+### Why This Format?
+
+- **Caller gets actionable intelligence** without parsing verbose output
+- **Token cost stays in the sub-agent** — raw grep/read output never reaches main session
+- **No follow-up needed** — a good `<results>` block eliminates "but where exactly?" questions
+
+## 7 Required Elements (Prompt Quality = Delegation Quality)
+
+1. **TASK**: Clear, atomic task instruction
+2. **EXPECTED OUTCOME**: Deliverables and success criteria
+3. **REQUIRED SKILLS**: List of needed skills
+4. **REQUIRED TOOLS**: Tool whitelist
+5. **MUST DO**: Mandatory detailed requirements
+6. **MUST NOT DO**: Prohibitions (scope expansion, file modification, etc.)
+7. **CONTEXT**: Paths, constraints, existing patterns, downstream purpose
+
+### Output Compression Directive (Add to MUST DO)
+
+When delegating to read-only agents, always include:
+
+```
+MUST DO:
+- Return results in <results><files><answer><next_steps> format
+- Compress all findings into actionable summary — do NOT dump raw file contents
+- Use absolute paths only
+```
+
+## Examples
+
+### Example 1: Code Analysis (deep, background)
 ```
 sessions_spawn(
   task="""
-  1) TASK: /home/happycastle/Projects/my-app/src/ 디렉토리의 테스트 커버리지 분석
-  2) EXPECTED OUTCOME: 테스트 없는 파일 목록 + 우선순위별 테스트 작성 계획
+  1) TASK: Analyze test coverage for /home/happycastle/Projects/my-app/src/
+  2) EXPECTED OUTCOME: List of untested files + prioritized test writing plan
   3) REQUIRED SKILLS: none
   4) REQUIRED TOOLS: read, exec (jest --coverage)
-  5) MUST DO: 각 파일의 복잡도와 중요도 평가 포함
-  6) MUST NOT DO: 테스트 파일 직접 작성하지 말 것
-  7) CONTEXT: Jest + TypeScript 프로젝트, src/utils/는 가장 중요
+  5) MUST DO: Include complexity and importance assessment for each file.
+     Return results in <results><files><answer><next_steps> format.
+  6) MUST NOT DO: Do not write test files directly
+  7) CONTEXT: Jest + TypeScript project, src/utils/ is highest priority
   """,
   mode="run",
   model="claude-opus-4-6-thinking",
@@ -99,17 +160,18 @@ sessions_spawn(
 )
 ```
 
-### 예시 2: 웹 리서치 (quick, background)
+### Example 2: Web Research (quick, background)
 ```
 sessions_spawn(
   task="""
-  1) TASK: Next.js 15의 Server Actions 변경사항 조사
-  2) EXPECTED OUTCOME: 주요 변경점 요약 + 마이그레이션 가이드
+  1) TASK: Research Next.js 15 Server Actions changes
+  2) EXPECTED OUTCOME: Key changes summary + migration guide
   3) REQUIRED SKILLS: web-search
   4) REQUIRED TOOLS: web_fetch, exec (mcporter)
-  5) MUST DO: 공식 문서 + 커뮤니티 피드백 모두 확인
-  6) MUST NOT DO: 코드 수정하지 말 것
-  7) CONTEXT: 현재 Next.js 14 사용 중, 업그레이드 검토
+  5) MUST DO: Check both official docs and community feedback.
+     Return results in <results><files><answer><next_steps> format.
+  6) MUST NOT DO: Do not modify code
+  7) CONTEXT: Currently using Next.js 14, evaluating upgrade
   """,
   mode="run",
   model="claude-sonnet-4-6",
@@ -117,68 +179,94 @@ sessions_spawn(
 )
 ```
 
-### 예시 3: 병렬 작업 (여러 spawn 동시)
+### Example 3: Parallel Tasks (multiple spawns)
 ```
-# 동시에 3개 서브에이전트 실행
-sessions_spawn(task="파일 A 리팩토링...", mode="run", model="claude-opus-4-6-thinking", label="refactor-a")
-sessions_spawn(task="파일 B 리팩토링...", mode="run", model="claude-opus-4-6-thinking", label="refactor-b")
-sessions_spawn(task="테스트 작성...", mode="run", model="claude-sonnet-4-6", label="write-tests")
+# 3 sub-agents running simultaneously
+sessions_spawn(task="Refactor file A...", mode="run", model="claude-opus-4-6-thinking", label="refactor-a")
+sessions_spawn(task="Refactor file B...", mode="run", model="claude-opus-4-6-thinking", label="refactor-b")
+sessions_spawn(task="Write tests...", mode="run", model="claude-sonnet-4-6", label="write-tests")
 ```
 
-## omoc_delegate와의 관계
+## Relationship with omoc_delegate
 
-`omoc_delegate` 도구는 카테고리 → 모델 매핑만 해준다. 실제 서브에이전트 생성은 반드시 `sessions_spawn`을 호출해야 한다.
+`omoc_delegate` only handles category → model mapping. Actual sub-agent creation requires calling `sessions_spawn`.
 
-**올바른 흐름:**
-1. `omoc_delegate`로 카테고리/모델 확인 (선택적)
-2. `sessions_spawn`으로 실제 서브에이전트 생성
-3. 완료 시 자동 통지 수신 (push-based)
+**Correct flow:**
+1. Use `omoc_delegate` to check category/model (optional)
+2. Use `sessions_spawn` to create the actual sub-agent
+3. Receive automatic completion notification (push-based)
 
-**절대 하지 말 것:**
-- `subagents list`를 루프로 폴링하지 말 것 — 결과는 자동으로 돌아옴
-- spawn 후 즉시 결과를 기대하지 말 것 — 비동기 실행
+**Never do this:**
+- Do NOT poll `subagents list` in a loop — results arrive automatically
+- Do NOT expect immediate results after spawn — execution is asynchronous
+
+## Sub-Agent Routing Metadata
+
+When choosing whether to delegate, use these heuristics:
+
+### Explore Agent
+- **Use when**: Multiple search angles needed, unfamiliar module structure, cross-layer pattern discovery
+- **Avoid when**: You know exactly what to search, single keyword suffices, known file location
+
+### Librarian Agent
+- **Use when**: External library questions, "How do I use [X]?", unfamiliar packages, best practice lookups
+- **Avoid when**: Internal code only, no external dependencies involved
+
+### Oracle Agent
+- **Use when**: Architecture tradeoff decisions, complex debugging after repeated failures, design review
+- **Avoid when**: Simple implementation, no architectural implications
+
+### Metis Agent
+- **Use when**: Ambiguous task needs intent classification, risk of scope creep, pre-planning gap analysis
+- **Avoid when**: Task is clear and well-defined, simple implementation
+
+### Momus Agent
+- **Use when**: Plan needs executability review, catching critical blockers before implementation
+- **Avoid when**: Plan is simple enough to self-review, single-step task
 
 ## Quality Checklist
 
-- [ ] 결과 검증 기준이 측정 가능하다
-- [ ] 입력 경로/범위가 명시되어 있다
-- [ ] 금지사항이 모호하지 않다
-- [ ] 실패 시 재시도/보고 방식이 정의되어 있다
-- [ ] 적절한 카테고리/모델을 선택했다
-- [ ] mode가 맞다 (run=일회성, session=영구)
+- [ ] Success criteria are measurable
+- [ ] Input paths/scope are specified
+- [ ] Prohibitions are unambiguous
+- [ ] Failure retry/reporting strategy is defined
+- [ ] Correct category/model selected
+- [ ] Mode is correct (run=one-shot, session=persistent)
+- [ ] Output compression directive included for read-only agents
 
-## 서브에이전트 완료 후 행동 (강제)
+## Post-Completion Behavior (Mandatory)
 
-서브에이전트 완료 통지("✅ Subagent finished")는 **FYI가 아니라 행동 트리거**다.
+Sub-agent completion notifications ("✅ Subagent finished") are **action triggers, not FYI messages**.
 
-### 완료 통지를 받으면 반드시:
+### On receiving a completion notification:
 
-1. **결과 확인** — 서브에이전트가 산출한 결과를 즉시 읽는다
-2. **성공 기준 대조** — 위임 시 명시한 EXPECTED OUTCOME과 비교 검증한다
-3. **다음 단계 실행** — 검증 통과 시 즉시 다음 phase/step을 진행한다
-4. **실패 시 재시도** — 검증 실패 시 같은 에이전트로 재시도 (최대 3회) 또는 에스컬레이션
-5. **멈추지 않는다** — 모든 phase가 완료될 때까지 절대 멈추지 않는다
+1. **Check results** — immediately read the sub-agent's output
+2. **Verify against criteria** — compare with the delegated EXPECTED OUTCOME
+3. **Execute next step** — proceed to the next phase/step upon verification
+4. **Retry on failure** — re-delegate to the same agent (max 3 retries) or escalate
+5. **Never stop** — continue until all phases are complete
 
-### 금지사항:
+### Prohibited:
 
-- ❌ 완료 통지를 받고 아무 행동 없이 멈추기
-- ❌ "완료되었습니다"만 보고하고 결과를 확인하지 않기
-- ❌ 다음 phase가 있는데 사용자 확인을 기다리기 (자동 진행이 기본)
-- ❌ 서브에이전트 결과를 무시하고 직접 다시 작업하기
+- ❌ Receiving a completion notification and doing nothing
+- ❌ Reporting "done" without checking results
+- ❌ Waiting for user confirmation when the next phase is ready (auto-proceed is default)
+- ❌ Ignoring sub-agent results and redoing the work directly
 
-### 병렬 서브에이전트인 경우:
+### For parallel sub-agents:
 
-- 각 완료 통지마다 해당 결과를 수집한다
-- 모든 병렬 에이전트가 완료되면 의존 phase를 즉시 시작한다
-- 일부만 완료된 상태에서는 독립적인 다음 작업을 먼저 진행한다
+- Collect results from each completion notification
+- Start dependent phases immediately when all parallel agents finish
+- Proceed with independent next tasks while waiting for remaining agents
 
 ## Anti-Patterns
 
-- "적당히", "알아서" 같은 모호한 지시
-- 도구 무제한 허용
-- 컨텍스트 없는 대규모 요청
-- 기대 산출물이 없는 위임
-- spawn 후 poll 루프로 결과 대기
-- 모든 작업을 직접 처리 (서브에이전트 미활용)
-- 구현 작업인데 sessions_spawn 없이 직접 코드 수정
-- **완료 통지 후 멈추기 (가장 흔한 실패 패턴)**
+- Vague instructions like "figure it out" or "do your best"
+- Unlimited tool access
+- Large requests without context
+- Delegating without expected deliverables
+- Polling loops after spawn
+- Handling everything directly (not using sub-agents)
+- Modifying code directly when sessions_spawn should be used
+- **Stopping after completion notification (most common failure pattern)**
+- **Injecting raw file contents into the main session instead of delegating**

--- a/plugin/skills/gemini-look-at.md
+++ b/plugin/skills/gemini-look-at.md
@@ -1,160 +1,160 @@
 ---
 name: gemini-look-at
-description: Gemini CLI 기반 멀티모달 분석 스킬. PDF, 이미지, 스크린샷, 다이어그램을 Gemini의 네이티브 멀티모달 능력으로 분석한다. tmux gemini 세션을 통해 실행.
+description: Multimodal analysis skill using Gemini CLI. Analyzes PDFs, images, screenshots, and diagrams via Gemini's native multimodal capabilities. Runs through tmux gemini session.
 ---
 # Gemini Look-At — Multimodal Analysis via Gemini CLI
 
-OmO의 `look-at` 도구를 Gemini CLI + tmux로 재구현한 스킬.
-OpenClaw의 `read` 도구는 이미지를 첨부로 보내줄 수 있지만, **PDF는 읽을 수 없고**, Gemini CLI는 PDF/이미지/비디오를 네이티브로 분석할 수 있다.
+Re-implementation of OmO's `look-at` tool using Gemini CLI + tmux.
+OpenClaw's `read` tool can send images as attachments, but **cannot read PDFs natively**. Gemini CLI can analyze PDF/image/video natively.
 
-## 언제 사용하는가
+## When to Use
 
-- **PDF 분석** — 레이아웃, 디자인, 콘텐츠 품질 평가
-- **이미지/스크린샷 분석** — UI 리뷰, 버그 확인, 디자인 피드백
-- **다이어그램 해석** — 아키텍처, 플로우차트, ER 다이어그램 분석
-- **멀티 파일 비교** — 두 PDF/이미지를 동시에 비교
-- **OCR + 해석** — 스크린샷에서 텍스트 추출 + 의미 분석
+- **PDF analysis** — layout, design, content quality assessment
+- **Image/screenshot analysis** — UI review, bug verification, design feedback
+- **Diagram interpretation** — architecture, flowchart, ER diagram analysis
+- **Multi-file comparison** — compare two PDFs/images side by side
+- **OCR + interpretation** — extract text from screenshots + semantic analysis
 
-## Gemini CLI 기본 사용법
+## Gemini CLI Basics
 
 ```bash
-# 빠른 시작
-gemini "질문..."
+# Quick start
+gemini "your question..."
 
-# 모델 지정
-gemini --model <name> "프롬프트..."
+# Specify model
+gemini --model <name> "prompt..."
 
-# JSON 형식 출력
-gemini --output-format json "JSON 반환"
+# JSON output format
+gemini --output-format json "return JSON"
 
-# 확장(extensions) 목록 확인
+# List extensions
 gemini --list-extensions
 ```
 
-- 첫 실행 시 인터랙티브 로그인/인증이 필요하다.
-- `--yolo` 플래그는 사용하지 않는다.
+- First run requires interactive login/authentication.
+- Do NOT use the `--yolo` flag.
 
-## 실행 방법
+## Execution Methods
 
-### 방법 1: tmux gemini 세션 (권장)
+### Method 1: tmux gemini session (recommended)
 
-tmux `gemini` 세션이 이미 인증되어 있으므로 안정적.
+The tmux `gemini` session is already authenticated and stable.
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 SESSION="gemini"
 
-# 단일 파일 분석
+# Single file analysis
 tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- \
-  "gemini -m gemini-2.5-flash --prompt '이 파일을 분석해줘. 레이아웃, 디자인, 콘텐츠 품질을 평가하고 개선점을 제안해.' -f /path/to/file.pdf -o text" \
+  "gemini -m gemini-2.5-flash --prompt 'Analyze this file. Evaluate layout, design, content quality, and suggest improvements.' -f /path/to/file.pdf -o text" \
   && sleep 0.1 && tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 Enter
 
-# 결과 확인 (10-30초 대기 후)
+# Check results (wait 10-30 seconds)
 sleep 15
 tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
 ```
 
-### 방법 2: 결과를 파일로 저장
+### Method 2: Save output to file
 
-분석 결과가 길 때는 파일로 리다이렉트:
+When analysis output is long, redirect to a file:
 
 ```bash
 tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- \
-  "gemini -m gemini-2.5-flash --prompt '상세 분석' -f /path/to/file.pdf -o text > /tmp/gemini-analysis.md 2>&1" \
+  "gemini -m gemini-2.5-flash --prompt 'Detailed analysis' -f /path/to/file.pdf -o text > /tmp/gemini-analysis.md 2>&1" \
   && sleep 0.1 && tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 Enter
 
-# 결과 파일 읽기
+# Read result file
 sleep 20
 cat /tmp/gemini-analysis.md
 ```
 
-### 방법 3: 여러 파일 동시 분석
+### Method 3: Multi-file analysis
 
 ```bash
 tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- \
-  "gemini -m gemini-2.5-flash --prompt '두 파일을 비교해줘' -f /path/to/before.png -f /path/to/after.png -o text" \
+  "gemini -m gemini-2.5-flash --prompt 'Compare these two files' -f /path/to/before.png -f /path/to/after.png -o text" \
   && sleep 0.1 && tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 Enter
 ```
 
-## 분석 패턴별 프롬프트
+## Analysis Prompt Templates
 
-### PDF 레이아웃/디자인 리뷰
+### PDF Layout/Design Review
 ```
-이 PDF의 레이아웃, 줄넘김, 디자인을 평가해줘. 
-부자연스러운 부분이 있으면 구체적으로 알려줘.
-특히: 여백, 폰트 크기, 줄간격, 페이지 나눔, 표/이미지 배치를 체크해.
-```
-
-### 스크린샷 UI 리뷰
-```
-이 웹 UI 스크린샷을 분석해줘.
-1. 레이아웃 정렬과 간격 일관성
-2. 타이포그래피 계층 구조
-3. 색상 대비 및 접근성
-4. 인터랙티브 요소의 가시성
-5. 전체적인 디자인 품질 (1-10 점수)
-개선 제안을 구체적으로 해줘.
+Evaluate this PDF's layout, line breaks, and design.
+Point out any unnatural areas specifically.
+Check: margins, font sizes, line spacing, page breaks, table/image placement.
 ```
 
-### 아키텍처 다이어그램 해석
+### Screenshot UI Review
 ```
-이 아키텍처 다이어그램을 분석해줘.
-- 각 컴포넌트의 역할을 식별
-- 데이터 흐름 방향을 설명
-- 잠재적 병목점이나 단일 장애점을 식별
-- 개선 제안
-```
-
-### Before/After 비교
-```
-이 두 이미지를 비교해줘.
-- 바뀐 부분을 구체적으로 나열
-- 개선된 점과 퇴보한 점을 구분
-- 추가 개선 제안
+Analyze this web UI screenshot.
+1. Layout alignment and spacing consistency
+2. Typography hierarchy
+3. Color contrast and accessibility
+4. Interactive element visibility
+5. Overall design quality (1-10 score)
+Provide specific improvement suggestions.
 ```
 
-### 에러 스크린샷 디버깅
+### Architecture Diagram Interpretation
 ```
-이 에러 스크린샷을 분석해줘.
-- 에러 메시지를 정확히 읽어줘
-- 가능한 원인을 추정
-- 해결 방법을 제안
+Analyze this architecture diagram.
+- Identify each component's role
+- Describe data flow direction
+- Identify potential bottlenecks or single points of failure
+- Suggest improvements
 ```
 
-## 모델 선택 가이드
+### Before/After Comparison
+```
+Compare these two images.
+- List specific changes
+- Distinguish improvements from regressions
+- Suggest additional improvements
+```
 
-| 용도 | 추천 모델 | 이유 |
-|------|-----------|------|
-| 빠른 확인 | `gemini-2.5-flash` | 빠름, 충분한 멀티모달 능력 |
-| 상세 분석 | `gemini-2.5-pro` | 더 깊은 분석, 긴 콘텐츠 |
-| 최고 품질 | `gemini-3.1-pro` | 최신 모델, 최상의 멀티모달 |
+### Error Screenshot Debugging
+```
+Analyze this error screenshot.
+- Read the error message exactly
+- Estimate possible causes
+- Suggest solutions
+```
+
+## Model Selection Guide
+
+| Purpose | Recommended Model | Reason |
+|---------|-------------------|--------|
+| Quick check | `gemini-2.5-flash` | Fast, sufficient multimodal ability |
+| Detailed analysis | `gemini-2.5-pro` | Deeper analysis, long content |
+| Highest quality | `gemini-3.1-pro` | Latest model, best multimodal |
 
 ## OpenClaw read vs Gemini CLI
 
-| 기능 | OpenClaw `read` | Gemini CLI |
-|------|----------------|------------|
-| 이미지 (PNG/JPG) | ✅ 첨부로 전송 | ✅ 네이티브 분석 |
-| PDF | ❌ 텍스트만 | ✅ 레이아웃 포함 분석 |
-| 비디오 | ❌ | ✅ 프레임 분석 |
-| 여러 파일 동시 | ❌ 하나씩 | ✅ `-f` 여러 개 |
-| 인증 | 불필요 | tmux 세션 필요 |
+| Feature | OpenClaw `read` | Gemini CLI |
+|---------|----------------|------------|
+| Images (PNG/JPG) | ✅ Sent as attachment | ✅ Native analysis |
+| PDF | ❌ Text only | ✅ Layout-aware analysis |
+| Video | ❌ | ✅ Frame analysis |
+| Multiple files | ❌ One at a time | ✅ Multiple `-f` flags |
+| Authentication | Not needed | tmux session required |
 
-## 워크플로우: OpenCode + Gemini CLI 연계
+## Workflow: OpenCode + Gemini CLI Integration
 
-코딩 작업 중 시각적 확인이 필요할 때:
+When visual verification is needed during coding:
 
 ```
-1. OpenCode (tmux opencode 세션)에서 코드 작성/수정
-2. 빌드/렌더링 결과물 생성 (PDF, 스크린샷 등)
-3. Gemini CLI (tmux gemini 세션)로 결과물 시각적 품질 검증
-4. 문제 발견 시 → 다시 OpenCode로 돌아가서 수정
-5. 반복 (결과물 만족할 때까지)
+1. Write/modify code in OpenCode (tmux opencode session)
+2. Generate build/render output (PDF, screenshot, etc.)
+3. Verify visual quality with Gemini CLI (tmux gemini session)
+4. If issues found → return to OpenCode to fix
+5. Repeat until output is satisfactory
 ```
 
-## 주의사항
+## Important Notes
 
-- tmux `gemini` 세션이 반드시 실행 중이어야 함 (인증 상태 유지)
-- `capture-pane`으로 결과 확인 시 출력이 잘리면 `-S -500` 등으로 줄 수 늘리기
-- 파일 경로는 절대 경로 사용
-- 응답 대기: PDF 크기에 따라 10-60초 소요 가능
-- `--yolo` 플래그 사용 금지 (안전성)
+- The tmux `gemini` session MUST be running (maintains auth state)
+- If `capture-pane` output is truncated, increase lines with `-S -500`
+- Use absolute file paths
+- Response wait time: 10-60 seconds depending on PDF size
+- Do NOT use `--yolo` flag (safety)

--- a/plugin/skills/multimodal-analysis.md
+++ b/plugin/skills/multimodal-analysis.md
@@ -5,35 +5,35 @@ description: Multimodal file analysis skill for PDFs, images, and technical diag
 
 # Multimodal Analysis - File Analysis Skill
 
-OmO `look-at` 도구 패턴을 기반으로, 문서/이미지/다이어그램 분석을 표준화한다.
+Standardizes document/image/diagram analysis based on OmO's `look-at` tool pattern.
 
 ## Source Pattern (OmO)
 
-- `look-at`는 파일 경로 + 분석 목표(goal)를 받아 멀티모달 해석 수행
-- 핵심 입력은 단순하다: **무엇을 볼지** + **무엇을 추출할지**
+- `look-at` takes a file path + analysis goal and performs multimodal interpretation
+- Core input is simple: **what to look at** + **what to extract**
 
 ## Supported Inputs
 
-- PDF 문서
-- 일반 이미지(PNG/JPG/WebP)
-- 기술 다이어그램(architecture/flow/UML/ER)
+- PDF documents
+- Standard images (PNG/JPG/WebP)
+- Technical diagrams (architecture/flow/UML/ER)
 
 ## Analysis Patterns
 
 ### 1) PDF Analysis
 
-- 목표 예시: 요약, 정책/요건 추출, 변경점 비교
-- 출력: 핵심 항목 bullet + 필요한 경우 구조화 목록
+- Example goals: summarize, extract policies/requirements, compare changes
+- Output: key items as bullets + structured list when needed
 
 ### 2) Image Analysis
 
-- 목표 예시: 화면 구성요소 식별, 텍스트/라벨 추출, 상태 비교
-- 출력: 영역별 관찰 + actionable insight
+- Example goals: identify UI components, extract text/labels, compare states
+- Output: per-region observations + actionable insights
 
 ### 3) Diagram Analysis
 
-- 목표 예시: 컴포넌트 관계, 데이터 흐름, 병목/리스크 파악
-- 출력: 노드/엣지 해석 + 개선 포인트
+- Example goals: component relationships, data flow, bottleneck/risk identification
+- Output: node/edge interpretation + improvement points
 
 ## Prompt Template
 
@@ -46,13 +46,13 @@ Output: <summary|table|checklist>
 
 ## Recommended Workflow
 
-1. 목표를 1문장으로 명확화
-2. 파일 유형에 맞는 패턴 선택
-3. 분석 결과를 실행 가능한 액션으로 변환
-4. 불확실성은 "추정"으로 명시
+1. Clarify the goal in one sentence
+2. Select the appropriate pattern for the file type
+3. Convert analysis results into actionable items
+4. Mark uncertainty as "estimated" explicitly
 
 ## Guardrails
 
-- 파일 내용이 불명확하면 단정하지 않는다
-- OCR/시각 해석 결과는 근거와 함께 제시
-- 원문 인용이 필요하면 짧게, 과도한 복붙 금지
+- Do not make assertions when file content is unclear
+- Present OCR/visual interpretation results with supporting evidence
+- Keep source quotes brief; no excessive copy-paste

--- a/plugin/skills/opencode-controller.md
+++ b/plugin/skills/opencode-controller.md
@@ -1,61 +1,61 @@
 ---
 name: opencode-controller
-description: tmux의 OpenCode 세션을 제어한다. 세션 관리, 모델 선택, 에이전트 전환(Plan/Build), OmO 위임 패턴을 포함.
+description: Controls the OpenCode session in tmux. Includes session management, model selection, agent switching (Plan/Build), and OmO delegation patterns.
 ---
 
-# opencode-controller — OpenCode 세션 제어
+# opencode-controller — OpenCode Session Control
 
-OpenClaw는 직접 코드를 쓰는 실행기가 아니라, OpenCode에 작업을 위임해 결과를 수집/검증하는 오케스트레이터다.
+OpenClaw is not a code executor — it delegates work to OpenCode and collects/verifies results as an orchestrator.
 
-## 핵심 원칙
+## Core Principles
 
-- OpenClaw가 직접 코드를 작성하지 않는다
-- 코딩 작업은 tmux `opencode` 세션으로 위임한다
-- OpenClaw는 작업 분해, 지시, 모니터링, 결과 검증을 담당한다
+- OpenClaw does not write code directly
+- Coding tasks are delegated to the tmux `opencode` session
+- OpenClaw handles task decomposition, instruction, monitoring, and result verification
 
-## Pre-flight 체크
+## Pre-flight Check
 
-### 1) Provider/모델 선택
+### 1) Provider/Model Selection
 
-- 작업 난이도에 따라 OpenCode 모델 선택(quick/deep/ultrabrain)
-- 고난도 작업은 고성능 모델 우선
+- Select OpenCode model based on task difficulty (quick/deep/ultrabrain)
+- High-difficulty tasks should prefer high-performance models
 
-### 2) 인증 상태
+### 2) Authentication State
 
-- OpenCode CLI 제공자 인증이 완료되어 있어야 함
-- 인증 만료 시 세션 내에서 재로그인 후 재시도
+- OpenCode CLI provider authentication must be completed
+- If auth expires, re-login within the session and retry
 
-### 3) tmux 세션 확인
+### 3) tmux Session Check
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 tmux -S "$SOCKET" has-session -t opencode
 ```
 
-## 세션 관리
+## Session Management
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 
-# 세션 생성
+# Create session
 tmux -S "$SOCKET" new -d -s opencode -n main
 
-# 세션 상태
+# Session status
 tmux -S "$SOCKET" list-sessions
 
-# 세션 출력 확인
+# Check session output
 tmux -S "$SOCKET" capture-pane -p -J -t opencode:0.0 -S -200
 ```
 
-## 에이전트 제어
+## Agent Control
 
-OpenCode 에이전트 전환은 Tab 기반으로 수행한다.
+OpenCode agent switching is Tab-based.
 
-| 에이전트 | 용도 | 전환 |
-|----------|------|------|
-| Sisyphus | 기본 구현/수정 | 기본 상태 |
-| Hephaestus | 깊은 구현/리팩토링 | Tab 1회 |
-| Prometheus | 계획 수립/전략화 | Tab 2회 |
+| Agent | Purpose | Switch |
+|-------|---------|--------|
+| Sisyphus | Default implementation/fixes | Default state |
+| Hephaestus | Deep implementation/refactoring | Tab x1 |
+| Prometheus | Planning/strategy | Tab x2 |
 
 ```bash
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Tab
@@ -63,109 +63,109 @@ sleep 1
 tmux -S "$SOCKET" capture-pane -p -J -t opencode:0.0 -S -20
 ```
 
-## 모델 선택 가이드
+## Model Selection Guide
 
-- 빠른 수정: 속도 우선 모델
-- 복잡한 리팩토링/설계: 심층 추론 모델
-- 계획 전용 단계: 최고 추론 모델 우선
+- Quick fixes: speed-priority model
+- Complex refactoring/design: deep reasoning model
+- Planning-only phase: highest reasoning model preferred
 
-실행 시점에 프로젝트 표준 라우팅(quick/deep/ultrabrain)을 따른다.
+Follow the project standard routing (quick/deep/ultrabrain) at execution time.
 
-## Plan -> Build 워크플로우
+## Plan → Build Workflow
 
-1) Prometheus로 계획 수립
-2) 계획 승인/정리
-3) Sisyphus 또는 Hephaestus로 구현 전환
-4) 테스트/빌드/검증 실행
-5) 결과를 OpenClaw가 수집해 최종 보고
+1) Create plan with Prometheus
+2) Approve/refine the plan
+3) Switch to Sisyphus or Hephaestus for implementation
+4) Run tests/build/verification
+5) OpenClaw collects results and delivers final report
 
 ```bash
-# Plan 단계
+# Plan phase
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Tab
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Tab
 sleep 0.2
-tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- '계획 수립: 인증 모듈 리팩토링 범위/리스크/검증전략 작성'
+tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'Plan: auth module refactoring scope/risk/verification strategy'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 
-# Build 단계 전환(예: Sisyphus로 복귀 후 구현)
+# Build phase (switch back to Sisyphus for implementation)
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Escape
-tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'ultrawork 위 계획 기준으로 구현 시작, 테스트까지 완료'
+tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'ultrawork implement based on the plan above, complete with tests'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 ```
 
-## OmO 위임 패턴
+## OmO Delegation Pattern
 
-### 1) tmux 세션 검증
+### 1) tmux Session Verification
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 tmux -S "$SOCKET" has-session -t opencode
 ```
 
-### 2) 에이전트 선택표
+### 2) Agent Selection
 
-| 목적 | 에이전트 | 전환 |
-|------|----------|------|
-| 기본 실행 | Sisyphus | 기본 |
-| 깊은 구현 | Hephaestus | Tab 1회 |
-| 계획 수립 | Prometheus | Tab 2회 |
+| Purpose | Agent | Switch |
+|---------|-------|--------|
+| Default execution | Sisyphus | Default |
+| Deep implementation | Hephaestus | Tab x1 |
+| Planning | Prometheus | Tab x2 |
 
-### 3) 작업 전송 (`send-keys -l` + Enter 분리)
+### 3) Task Sending (`send-keys -l` + separate Enter)
 
 ```bash
-TASK='ultrawork 결제 실패 버그 수정. 재현, 원인 분석, 테스트 추가, 회귀 방지 포함.'
+TASK='ultrawork fix payment failure bug. Include reproduction, root cause analysis, test addition, regression prevention.'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- "$TASK"
 sleep 0.1
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 ```
 
-### 4) 작업 템플릿
+### 4) Task Templates
 
-기능 구현:
+Feature implementation:
 ```text
-ultrawork [기능] 구현.
-요구사항:
-- [요구 1]
-- [요구 2]
-기존 [참조 파일] 패턴을 따르고 테스트까지 수행.
+ultrawork implement [feature].
+Requirements:
+- [requirement 1]
+- [requirement 2]
+Follow existing [reference file] patterns and run tests.
 ```
 
-버그 수정:
+Bug fix:
 ```text
-ultrawork [버그 설명] 수정.
-재현 경로: [steps]
-에러: [message]
-기대 동작: [expected]
+ultrawork fix [bug description].
+Reproduction: [steps]
+Error: [message]
+Expected: [expected behavior]
 ```
 
-리팩토링:
+Refactoring:
 ```text
-ultrawork [모듈] 리팩토링.
-목표:
-- [목표 1]
-- [목표 2]
-제약:
-- Public API 변경 금지
-- 기존 테스트 통과
+ultrawork refactor [module].
+Goals:
+- [goal 1]
+- [goal 2]
+Constraints:
+- No public API changes
+- Existing tests must pass
 ```
 
-리서치 + 구현:
+Research + implementation:
 ```text
-[/path/to/research.md]를 먼저 읽고,
-ultrawork 연구 결과 기준으로 [기능] 구현.
+Read [/path/to/research.md] first,
+ultrawork implement [feature] based on research findings.
 ```
 
-### 5) 진행 모니터링 (`capture-pane`)
+### 5) Progress Monitoring (`capture-pane`)
 
 ```bash
 tmux -S "$SOCKET" capture-pane -p -J -t opencode:0.0 -S -200
 ```
 
-권장:
-- 10-30초 주기로 진행 로그 확인
-- 막힘 징후(동일 출력 반복, 프롬프트 대기) 즉시 개입
+Recommendations:
+- Check progress logs at 10-30 second intervals
+- Intervene immediately on stall signs (repeated output, prompt waiting)
 
-### 6) 결과 수집 (`git status`/`git diff`)
+### 6) Result Collection (`git status`/`git diff`)
 
 ```bash
 git status
@@ -173,25 +173,25 @@ git diff --stat
 git diff
 ```
 
-OpenClaw는 변경 파일/테스트 결과/리스크를 요약해 사용자에게 전달한다.
+OpenClaw summarizes changed files/test results/risks and delivers to the user.
 
-### 7) 에러 복구
+### 7) Error Recovery
 
 ```bash
-# 현재 동작 중단
+# Stop current operation
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Escape
 
-# 수정 지시 재전송
-tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- '직전 단계에서 테스트 실패 원인만 먼저 해결해.'
+# Resend corrected instruction
+tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'Resolve only the test failure from the previous step first.'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 
-# 세션 재시작
+# Session restart
 tmux -S "$SOCKET" kill-session -t opencode
 tmux -S "$SOCKET" new -d -s opencode -n main
 ```
 
-## 운영 체크리스트
+## Operations Checklist
 
-- 세션 alive 확인 -> 에이전트 선택 -> 작업 전송 -> 모니터링 -> 결과 수집
-- 항상 `send-keys -l` + 별도 Enter
-- 결과 보고 전에 `git status`/`git diff`로 변경 검증
+- Session alive check → agent selection → task send → monitoring → result collection
+- Always use `send-keys -l` + separate Enter
+- Verify changes with `git status`/`git diff` before reporting results

--- a/plugin/skills/steering-words.md
+++ b/plugin/skills/steering-words.md
@@ -5,55 +5,55 @@ description: Detect ultrawork/search/analyze family keywords in multilingual pro
 
 # Steering Words - Keyword Detection Skill
 
-키워드 기반으로 사용자 의도를 빠르게 분류하고 적절한 에이전트 모드를 추천한다.
+Quickly classify user intent based on keywords and recommend the appropriate agent mode.
 
-## 목적
+## Purpose
 
-- 입력 프롬프트에서 **steering words**를 감지
-- `ultrawork / search / analyze` 패밀리로 분류
-- 한국어/일본어/중국어 키워드를 포함해 모드 추천
+- Detect **steering words** in input prompts
+- Classify into `ultrawork / search / analyze` families
+- Recommend mode including multilingual keywords (Korean, Japanese, Chinese)
 
 ## Detection Families
 
 ### 1) Ultrawork Family
 
 - English: `ultrawork`, `ulw`, `full throttle`, `maximum effort`, `deep think`
-- 한국어: `울트라워크`, `풀가동`, `최대 노력`, `끝까지`, `전부 자동`
-- 日本語: `ウルトラワーク`, `全力`, `最大努力`, `最後まで`, `自動実行`
-- 中文: `超强模式`, `全力模式`, `最大努力`, `一路做完`, `全自动`
+- Korean: `울트라워크`, `풀가동`, `최대 노력`, `끝까지`, `전부 자동`
+- Japanese: `ウルトラワーク`, `全力`, `最大努力`, `最後まで`, `自動実行`
+- Chinese: `超强模式`, `全力模式`, `最大努力`, `一路做完`, `全自动`
 
-**추천 모드**
-- 우선: `/ultrawork`
-- 대안: 복잡 구현이면 `hephaestus`, 복잡 계획이면 `prometheus`
+**Recommended mode**
+- Primary: `/ultrawork`
+- Alternative: `hephaestus` for complex implementation, `prometheus` for complex planning
 
 ### 2) Search Family
 
 - English: `search`, `find`, `locate`, `lookup`, `scan`, `trace`, `where is`, `list all`
-- 한국어: `찾아`, `검색`, `어디`, `전부 보여`, `목록`
-- 日本語: `探して`, `検索`, `どこ`, `一覧`, `全部見せて`
-- 中文: `查找`, `搜索`, `哪里`, `列出`, `全部显示`
+- Korean: `���아`, `검색`, `어디`, `전부 보여`, `목록`
+- Japanese: `探して`, `検索`, `どこ`, `一覧`, `全部見せて`
+- Chinese: `查找`, `搜索`, `哪里`, `列出`, `全部显示`
 
-**추천 모드**
-- 우선: `explore` (코드베이스 탐색)
-- 외부 문서/OSS 필요 시: `librarian` 병행
+**Recommended mode**
+- Primary: `explore` (codebase search)
+- Supplement with `librarian` when external docs/OSS are needed
 
 ### 3) Analyze Family
 
 - English: `analyze`, `analyse`, `investigate`, `examine`, `research`, `audit`, `why`, `how does`
-- 한국어: `분석`, `조사`, `검토`, `원인`, `왜`, `어떻게`
-- 日本語: `分析`, `調査`, `検証`, `原因`, `なぜ`, `どうして`
-- 中文: `分析`, `调查`, `排查`, `原因`, `为什么`, `怎么`
+- Korean: `분석`, `조사`, `검토`, `원인`, `왜`, `어떻게`
+- Japanese: `分析`, `調査`, `検証`, `原因`, `なぜ`, `どうして`
+- Chinese: `分析`, `调查`, `排查`, `原因`, `为什么`, `怎么`
 
-**추천 모드**
-- 우선: `metis` (의도 분류/범위 정제)
-- 아키텍처 트레이드오프 포함 시: `oracle`
+**Recommended mode**
+- Primary: `metis` (intent classification / scope refinement)
+- Include `oracle` when architecture tradeoffs are involved
 
 ## Scoring Rule
 
-1. 패밀리별 키워드 매칭 수를 집계
-2. 최다 점수 패밀리를 선택
-3. 동점이면 우선순위: `ultrawork > analyze > search`
-4. 모호하면 `metis` 추천 후 재분류
+1. Count keyword matches per family
+2. Select the highest-scoring family
+3. On tie, priority order: `ultrawork > analyze > search`
+4. If ambiguous, recommend `metis` for re-classification
 
 ## Output Template
 
@@ -67,6 +67,6 @@ description: Detect ultrawork/search/analyze family keywords in multilingual pro
 
 ## Guardrails
 
-- 키워드 감지는 힌트이며 절대 규칙이 아니다.
-- 명시적 사용자 지시가 있으면 키워드보다 우선한다.
-- 다국어 혼합 입력은 단일 언어로 정규화하지 말고 그대로 매칭한다.
+- Keyword detection is a hint, not an absolute rule.
+- Explicit user instructions take precedence over keywords.
+- Do not normalize multilingual mixed input into a single language — match as-is.

--- a/plugin/skills/tmux-agents.md
+++ b/plugin/skills/tmux-agents.md
@@ -1,103 +1,103 @@
 ---
 name: tmux-agents
-description: tmux 세션에서 코딩 에이전트(Claude Code, Codex, Gemini, Ollama)를 스폰하고 모니터링한다.
+description: Spawn and monitor coding agents (Claude Code, Codex, Gemini, Ollama) in tmux sessions.
 ---
 
-# tmux-agents — 에이전트 스폰/모니터링 가이드
+# tmux-agents — Agent Spawn/Monitoring Guide
 
-tmux 안에서 코딩 에이전트를 띄우고, 상태를 확인하고, 병렬로 운영하는 실행 패턴 모음.
+Patterns for spawning coding agents in tmux, checking status, and running parallel operations.
 
-## 에이전트 종류
+## Agent Types
 
-| 구분 | 에이전트 ID | 실행 위치 | 특성 |
-|------|-------------|----------|------|
-| cloud | `claude` | 원격 API | 고품질 추론, 안정적 |
-| cloud | `codex` | 원격 API | 코드 생성/수정 강점 |
-| cloud | `gemini` | 원격 API | 멀티모달/긴 문맥 강점 |
-| local | `ollama-claude` | 로컬 Ollama | 비용 절감, 오프라인 가능 |
-| local | `ollama-codex` | 로컬 Ollama | 로컬 코드 작업 최적화 |
+| Type | Agent ID | Runtime | Characteristics |
+|------|----------|---------|-----------------|
+| cloud | `claude` | Remote API | High-quality reasoning, stable |
+| cloud | `codex` | Remote API | Strong code generation/modification |
+| cloud | `gemini` | Remote API | Strong multimodal/long context |
+| local | `ollama-claude` | Local Ollama | Cost reduction, offline capable |
+| local | `ollama-codex` | Local Ollama | Optimized for local code tasks |
 
-## 빠른 명령 모음
+## Quick Commands
 
-아래 명령은 tmux-agents 헬퍼 스크립트 인터페이스를 기준으로 한다.
+Commands below follow the tmux-agents helper script interface.
 
 ```bash
-# 1) 스폰
+# 1) Spawn
 ./spawn.sh --agent codex --session opencode-2 --cwd /path/to/project
 
-# 2) 목록
+# 2) List
 ./status.sh list
 
-# 3) 헬스체크
+# 3) Health check
 ./check.sh --session opencode-2
 
-# 4) 붙기
+# 4) Attach
 tmux attach -t opencode-2
 
-# 5) 지시 전송 (안전 입력)
+# 5) Send instruction (safe input)
 tmux send-keys -t opencode-2:0.0 -l -- 'Fix failing tests in auth module'
 tmux send-keys -t opencode-2:0.0 Enter
 
-# 6) 종료
+# 6) Kill
 tmux kill-session -t opencode-2
 ```
 
-## 병렬 에이전트 패턴
+## Parallel Agent Pattern
 
 ```bash
-# 병렬 스폰 예시
+# Parallel spawn example
 ./spawn.sh --agent codex --session opencode --cwd /repo/a
 ./spawn.sh --agent claude --session opencode-2 --cwd /repo/b
 ./spawn.sh --agent gemini --session gemini --cwd /repo/a
 
-# 병렬 진행 후 상태 점검
+# Status check after parallel progress
 ./status.sh list
 ./check.sh --session opencode
 ./check.sh --session opencode-2
 ./check.sh --session gemini
 ```
 
-운영 원칙:
-- 구현 세션과 검증 세션을 분리
-- 긴 작업은 10-30초 간격으로 주기 점검
-- 완료 후 세션별 결과를 순차 수집
+Operational principles:
+- Separate implementation sessions from verification sessions
+- Check long tasks at 10-30 second intervals
+- Collect results sequentially after completion
 
-## Local vs Cloud 선택 기준
+## Local vs Cloud Selection
 
-| 상황 | 권장 | 이유 |
-|------|------|------|
-| 속도보다 품질이 중요 | cloud | 최신 모델 품질/추론 강점 |
-| 장시간 반복 작업 | local | 비용 절감, 호출 제한 없음 |
-| 외부 네트워크 제약 | local | 오프라인/폐쇄망 대응 |
-| 멀티모달 분석 필요 | cloud(gemini) | 이미지/PDF 처리 품질 |
-| 민감 코드 로컬 처리 | local | 데이터 외부 전송 최소화 |
+| Situation | Recommended | Reason |
+|-----------|-------------|--------|
+| Quality over speed | cloud | Latest model quality/reasoning strength |
+| Long repeated tasks | local | Cost reduction, no rate limits |
+| Network restrictions | local | Offline/air-gapped compatibility |
+| Multimodal analysis needed | cloud (gemini) | Image/PDF processing quality |
+| Sensitive code processing | local | Minimize data exfiltration |
 
-## Ollama 준비
+## Ollama Setup
 
 ```bash
-# Ollama 실행 확인
+# Check Ollama status
 ollama list
 
-# 필요한 모델 다운로드(예시)
+# Download required models (example)
 ollama pull qwen2.5-coder:14b
 ollama pull llama3.1:8b
 
-# 로컬 응답 확인
+# Verify local response
 curl http://127.0.0.1:11434/api/tags
 ```
 
-권장:
-- 코딩용 모델 + 범용 대화 모델 1개씩 준비
-- RAM/VRAM 한계를 고려해 동시 실행 수 제한
+Recommendations:
+- Prepare one coding model + one general conversation model
+- Limit concurrent executions considering RAM/VRAM limits
 
-## 팁
+## Tips
 
-- 세션 타겟은 항상 `session:window.pane`으로 고정 (`opencode-2:0.0`)
-- 텍스트 입력은 `send-keys -l` 후 Enter 분리
-- 출력 확인은 `capture-pane -p -J -S -200` 기본 사용
-- 실패 세션은 즉시 재생성하고 동일 프롬프트 재투입
+- Always specify session targets as `session:window.pane` (`opencode-2:0.0`)
+- Text input: `send-keys -l` followed by separate Enter
+- Output check: use `capture-pane -p -J -S -200` as default
+- Failed sessions: immediately recreate and re-send the same prompt
 
-## 헬퍼 스크립트 범위
+## Helper Script Scope
 
-`spawn.sh`, `status.sh`, `check.sh`는 공식 `openclaw/skills/tmux-agents` 패키지에서 제공되는 헬퍼 스크립트 인터페이스를 따른다.
-이 문서는 스크립트 사용법 자체가 아니라, OpenClaw/OmO 운영 관점의 실행 지식을 제공한다.
+`spawn.sh`, `status.sh`, `check.sh` follow the helper script interface provided by the official `openclaw/skills/tmux-agents` package.
+This document provides operational knowledge from the OpenClaw/OmO perspective, not script usage itself.

--- a/plugin/skills/web-search.md
+++ b/plugin/skills/web-search.md
@@ -1,133 +1,133 @@
 ---
 name: web-search
-description: 웹 검색 및 정보 수집 스킬. OmO의 websearch/context7/grep_app MCP 패턴을 OpenClaw 네이티브 도구 + mcporter MCP로 통합. 웹 검색, 페이지 읽기, 라이브러리 문서 검색, 오픈소스 코드 검색을 지원한다.
+description: Web search and information gathering skill. Integrates OmO's websearch/context7/grep_app MCP patterns into OpenClaw native tools + mcporter MCP. Supports web search, page reading, library docs search, and open-source code search.
 ---
 
 # Web Search Skill
 
-웹에서 정보를 수집하는 통합 스킬. OpenClaw 네이티브 도구(`web_fetch`)와 mcporter MCP 서버를 조합하여 다양한 검색 전략을 제공한다.
+Unified skill for gathering information from the web. Combines OpenClaw native tools (`web_fetch`) with mcporter MCP servers to provide diverse search strategies.
 
-## 도구 우선순위
+## Tool Priority
 
-상황에 따라 최적의 도구를 선택:
+Select the optimal tool based on the situation:
 
-### 1. OpenClaw 네이티브 `web_fetch` (기본)
-가장 빠르고 간단. URL을 알고 있거나 간단한 페이지 읽기에 적합.
+### 1. OpenClaw Native `web_fetch` (default)
+Fastest and simplest. Best when you have the URL or need simple page reading.
 ```
 web_fetch(url="https://example.com", extractMode="markdown")
 ```
-- 별도 설정 불필요
-- HTML → markdown/text 자동 변환
-- `maxChars`로 응답 크기 제한 가능
+- No additional setup needed
+- Auto-converts HTML → markdown/text
+- Response size limitable via `maxChars`
 
-### 2. mcporter `web-search-prime` (웹 검색)
-키워드 기반 웹 검색. 최신 정보, 뉴스, 기술 블로그 검색에 적합.
+### 2. mcporter `web-search-prime` (web search)
+Keyword-based web search. Best for latest info, news, tech blogs.
 ```bash
 mcporter call web-search-prime.webSearchPrime \
-  search_query="검색어" \
+  search_query="search terms" \
   location="us" \
   content_size="medium"
 ```
-**파라미터:**
-- `search_query` (필수): 검색 키워드
-- `location`: `us` | `kr` | `jp` 등 (기본: `us`)
-- `content_size`: `medium` (기본) | `high` (상세, ~2500자)
+**Parameters:**
+- `search_query` (required): Search keywords
+- `location`: `us` | `kr` | `jp` etc. (default: `us`)
+- `content_size`: `medium` (default) | `high` (detailed, ~2500 chars)
 - `search_recency_filter`: `oneDay` | `oneWeek` | `oneMonth` | `oneYear` | `noLimit`
 
-### 3. mcporter `web-reader` (페이지 전문 읽기)
-특정 URL의 전체 내용을 깔끔하게 추출. `web_fetch`보다 정확한 추출이 필요할 때.
+### 3. mcporter `web-reader` (full page reading)
+Clean extraction of full page content. Use when `web_fetch` extraction is incomplete.
 ```bash
 mcporter call web-reader.webReader \
   url="https://example.com" \
   return_format="markdown"
 ```
-**파라미터:**
-- `url` (필수): 읽을 URL
-- `return_format`: `markdown` (기본) | `text`
-- `retain_images`: `true` (기본) | `false`
-- `with_links_summary`: `true` | `false` (문서 내 링크 요약)
+**Parameters:**
+- `url` (required): URL to read
+- `return_format`: `markdown` (default) | `text`
+- `retain_images`: `true` (default) | `false`
+- `with_links_summary`: `true` | `false` (summarize links in doc)
 
-### 4. mcporter `exa` (시맨틱 웹 검색)
-OmO의 기본 웹서치. 의미 기반(semantic) 검색으로 키워드보다 정확한 결과.
+### 4. mcporter `exa` (semantic web search)
+OmO's default web search. Semantic search for more accurate results than keywords.
 ```bash
 mcporter call exa.web_search_exa \
-  query="검색어"
+  query="search terms"
 ```
-- API 키 없이도 동작 (기본 제공)
-- 시맨틱 검색 지원 (질문 형태로 검색하면 더 좋은 결과)
+- Works without API key (provided by default)
+- Semantic search (question-form queries yield better results)
 
-### 5. mcporter `context7` (라이브러리 문서 검색)
-프로그래밍 라이브러리/프레임워크의 공식 문서를 검색.
+### 5. mcporter `context7` (library docs search)
+Search official docs for programming libraries/frameworks.
 ```bash
-# 라이브러리 검색
+# Find library
 mcporter call context7.resolve-library-id \
   libraryName="react"
 
-# 문서 검색
+# Search docs
 mcporter call context7.query-docs \
   libraryId="/facebook/react" \
   query="hooks"
 ```
-**용도:**
-- 라이브러리 API 레퍼런스 확인
-- 프레임워크 사용법 검색
-- 최신 버전 변경사항 확인
+**Use for:**
+- Library API reference lookup
+- Framework usage search
+- Latest version changelog
 
-### 6. mcporter `grep_app` (오픈소스 코드 검색)
-GitHub 등 오픈소스 코드에서 패턴/사용 예시를 검색.
+### 6. mcporter `grep_app` (open-source code search)
+Search patterns/usage examples in GitHub and other open-source code.
 ```bash
 mcporter call grep_app.search \
   query="useEffect cleanup" \
   language="typescript"
 ```
-**용도:**
-- 실제 프로젝트에서의 API 사용 예시 찾기
-- 특정 패턴/에러의 해결책 검색
-- 라이브러리 통합 방법 확인
+**Use for:**
+- Finding real-world API usage examples
+- Searching for pattern/error solutions
+- Library integration examples
 
-### 7. mcporter `zread` (GitHub 리포 직접 탐색)
-특정 GitHub 리포지토리의 파일/문서를 직접 읽기.
+### 7. mcporter `zread` (GitHub repo direct access)
+Directly read files/docs from specific GitHub repositories.
 ```bash
-# 리포 구조 확인
+# Check repo structure
 mcporter call zread.get_repo_structure \
   repo_name="owner/repo"
 
-# 파일 읽기
+# Read file
 mcporter call zread.read_file \
   repo_name="owner/repo" \
   file_path="src/index.ts"
 
-# 문서/이슈 검색
+# Search docs/issues
 mcporter call zread.search_doc \
   repo_name="owner/repo" \
-  query="검색어"
+  query="search terms"
 ```
 
-## 검색 전략 가이드
+## Search Strategy Guide
 
-### 일반 검색 (뉴스, 블로그, 일반 정보)
-1. `web-search-prime` → 검색 결과 → `web_fetch`로 상세 페이지 읽기
+### General Search (news, blogs, general info)
+1. `web-search-prime` → results → `web_fetch` for detailed page reading
 
-### 기술 문서 검색
-1. `context7`로 라이브러리 문서 직접 검색
-2. 없으면 `web-search-prime`으로 공식 문서 URL 찾기 → `web_fetch`
+### Technical Documentation
+1. `context7` for direct library docs search
+2. If not found, `web-search-prime` to find official docs URL → `web_fetch`
 
-### 코드 예시 검색
-1. `grep_app`으로 오픈소스 코드에서 패턴 검색
-2. `zread`로 특정 리포 파일 직접 읽기
-3. `context7`로 라이브러리 공식 예시 확인
+### Code Examples
+1. `grep_app` for pattern search in open-source code
+2. `zread` for direct file reading from specific repos
+3. `context7` for official library examples
 
-### 특정 사이트 정보
-1. `web_fetch`로 직접 URL 읽기 (가장 빠름)
-2. 내용 추출이 불완전하면 `web-reader`로 재시도
+### Specific Site Info
+1. `web_fetch` for direct URL reading (fastest)
+2. If extraction is incomplete, retry with `web-reader`
 
-### 최신 정보 (오늘/이번 주)
-1. `web-search-prime` + `search_recency_filter="oneDay"` 또는 `"oneWeek"`
-2. `exa`로 시맨틱 검색 보완
+### Latest Info (today/this week)
+1. `web-search-prime` + `search_recency_filter="oneDay"` or `"oneWeek"`
+2. Supplement with `exa` semantic search
 
-## mcporter 설정
+## mcporter Configuration
 
-MCP 서버들은 `~/.openclaw/workspace/config/mcporter.json`에 설정되어 있다:
+MCP servers are configured in `~/.openclaw/workspace/config/mcporter.json`:
 
 ```json
 {
@@ -142,14 +142,14 @@ MCP 서버들은 `~/.openclaw/workspace/config/mcporter.json`에 설정되어 �
 }
 ```
 
-## OmO 대응표
+## OmO Mapping Table
 
-| OmO (MCP)       | oh-my-openclaw 대응                              |
-|------------------|--------------------------------------------------|
-| `websearch` (Exa)| `mcporter call exa.web_search_exa` + `web_fetch` |
-| `websearch` (Tavily)| `mcporter call web-search-prime.webSearchPrime`|
-| `context7`       | `mcporter call context7.resolve-library-id` / `.query-docs` |
-| `grep_app`       | `mcporter call grep_app.search`                  |
-| *(없음)*         | `web_fetch` (OpenClaw 네이티브)                   |
-| *(없음)*         | `web-reader` (MCP, 깔끔한 페이지 추출)            |
-| *(없음)*         | `zread` (MCP, GitHub 리포 직접 탐색)               |
+| OmO (MCP) | oh-my-openclaw equivalent |
+|-----------|---------------------------|
+| `websearch` (Exa) | `mcporter call exa.web_search_exa` + `web_fetch` |
+| `websearch` (Tavily) | `mcporter call web-search-prime.webSearchPrime` |
+| `context7` | `mcporter call context7.resolve-library-id` / `.query-docs` |
+| `grep_app` | `mcporter call grep_app.search` |
+| *(none)* | `web_fetch` (OpenClaw native) |
+| *(none)* | `web-reader` (MCP, clean page extraction) |
+| *(none)* | `zread` (MCP, direct GitHub repo access) |

--- a/plugin/skills/workflow-auto-rescue.md
+++ b/plugin/skills/workflow-auto-rescue.md
@@ -5,26 +5,26 @@ description: Session recovery workflow with checkpointing, failure detection, an
 
 # Auto-Rescue Workflow
 
-장시간 작업 중 실패/중단 상황에서 세션을 자동 복구한다.
+Automatically recover sessions after failure/interruption during long-running tasks.
 
 ## When to Use
 
-- 긴 구현/리팩터링 세션
-- 다중 단계 작업(5+ step)
-- 반복 실패 가능성이 높은 디버깅/빌드 복구 작업
+- Long implementation/refactoring sessions
+- Multi-step tasks (5+ steps)
+- Debugging/build recovery tasks with high failure probability
 
 ## Core Mechanism
 
-- **Checkpoint 저장**: 주요 단계마다 `write` 도구로 파일 저장 (`workspace/checkpoints/`)
-- **Checkpoint 조회**: 복구 시 `read` 도구 + `memory_search` (OpenClaw 네이티브)
-- **자동 복원**: 가장 최근 정상 상태부터 재시작
+- **Checkpoint save**: Save file via `write` tool at major steps (`workspace/checkpoints/`)
+- **Checkpoint lookup**: Use `read` tool + `memory_search` (OpenClaw native) for recovery
+- **Auto-restore**: Restart from the most recent healthy state
 
-> **Note**: OpenClaw의 `group:memory`에는 `memory_search`/`memory_get`만 존재하고
-> `memory_store`는 없다. 저장은 반드시 파일 기반(`write`)으로 수행한다.
+> **Note**: OpenClaw's `group:memory` only has `memory_search`/`memory_get`.
+> `memory_store` does not exist. Storage must be file-based (`write`).
 
 ## Checkpoint Schema
 
-`workspace/checkpoints/checkpoint-<timestamp>.json`에 다음 형태로 저장한다:
+Save to `workspace/checkpoints/checkpoint-<timestamp>.json` in this format:
 
 ```json
 {
@@ -47,56 +47,56 @@ description: Session recovery workflow with checkpointing, failure detection, an
 
 ### 1) Start Monitoring
 
-1. 세션 시작 시 checkpoint baseline 저장 (`write` → `workspace/checkpoints/`)
-2. todo 기준으로 단계 전환마다 checkpoint 갱신
-3. 실패 가능 작업 전(대규모 edit/build/test) 선저장
+1. Save checkpoint baseline at session start (`write` → `workspace/checkpoints/`)
+2. Update checkpoint at every step transition (based on todos)
+3. Pre-save before potentially failing tasks (large edit/build/test)
 
 ### 2) Failure Detection
 
-다음 중 하나면 rescue 트리거:
+Trigger rescue if any of these occur:
 
-- 동일 오류 3회 연속 발생
-- 빌드/테스트가 연속 실패하고 진행 불가
-- 세션 중단(타임아웃/강제 인터럽트/에이전트 중지)
+- Same error 3 consecutive times
+- Build/test continuously failing with no progress possible
+- Session interruption (timeout/forced interrupt/agent stop)
 
 ### 3) Recovery Procedure
 
-1. `read` 도구로 `workspace/checkpoints/` 내 최근 checkpoint 파일 읽기
-2. 가장 최신 `verification`이 정상(pass)인 지점 선택
-3. 해당 시점의 `next_action`부터 재개
-4. 동일 실패 재발 시 한 단계 이전 checkpoint로 롤백
+1. Read the most recent checkpoint file from `workspace/checkpoints/` via `read` tool
+2. Select the latest checkpoint where `verification` is passing
+3. Resume from that checkpoint's `next_action`
+4. If same failure recurs, roll back to one checkpoint earlier
 
 ### 4) Post-Recovery
 
-1. 복구 성공 상태를 새 checkpoint 파일로 저장 (`write`)
-2. 실패 원인/해결을 `workspace/notepads/issues.md`에 기록
-3. 남은 단계 계속 진행
+1. Save recovery success state as a new checkpoint file (`write`)
+2. Record failure cause/resolution in `workspace/notepads/issues.md`
+3. Continue with remaining steps
 
 ## OpenClaw Tool Mapping
 
-| 동작            | 사용할 도구     | 비고                                         |
-| --------------- | --------------- | -------------------------------------------- |
-| Checkpoint 저장 | `write`         | `workspace/checkpoints/checkpoint-<ts>.json` |
-| Checkpoint 읽기 | `read`          | 직접 파일 경로 지정                          |
-| 과거 기억 검색  | `memory_search` | OpenClaw `group:memory`                      |
-| 특정 기억 조회  | `memory_get`    | key 기반                                     |
-| 파일 목록 확인  | `exec` (ls)     | checkpoint 디렉토리 스캔                     |
+| Action | Tool | Notes |
+|--------|------|-------|
+| Checkpoint save | `write` | `workspace/checkpoints/checkpoint-<ts>.json` |
+| Checkpoint read | `read` | Direct file path |
+| Search past context | `memory_search` | OpenClaw `group:memory` |
+| Get specific memory | `memory_get` | key-based |
+| List files | `exec` (ls) | Scan checkpoint directory |
 
 ## Example
 
 ```text
-# 저장
+# Save
 write({ path: "workspace/checkpoints/checkpoint-2026-02-22T13-00.json", content: "{ ... }" })
 
-# 복구 시 읽기
+# Read on recovery
 read({ path: "workspace/checkpoints/checkpoint-2026-02-22T13-00.json" })
 
-# 세션 기억에서 관련 컨텍스트 검색
+# Search session memory for related context
 memory_search({ query: "session-checkpoint auth refactor" })
 ```
 
 ## Completion Criteria
 
-- 복구 후 작업이 실제로 재개됨
-- 최신 checkpoint 파일이 저장됨
-- 동일 실패 루프가 차단됨
+- Work actually resumes after recovery
+- Latest checkpoint file is saved
+- Same-failure loops are blocked

--- a/plugin/skills/workflow-tool-patterns.md
+++ b/plugin/skills/workflow-tool-patterns.md
@@ -1,85 +1,85 @@
 ---
 name: workflow-tool-patterns
-description: OmO src/tools 패턴을 OpenClaw에서 재사용 가능한 실행 패턴으로 매핑하는 워크플로우
+description: Maps OmO src/tools patterns into reusable execution patterns for OpenClaw
 ---
 
 # Tool Patterns Workflow (OmO → OpenClaw)
 
-OmO의 `src/tools/` 구조를 기준으로, OpenClaw에서 실사용 가능한 도구 패턴을 표준화한다.
+Standardizes tool usage patterns in OpenClaw based on OmO's `src/tools/` structure.
 
-## 목적
+## Purpose
 
-- 도구 선택 실수를 줄이고
-- 반복 가능한 실행 루틴을 만들며
-- 계획/실행/검증 단계를 일관되게 유지한다.
+- Reduce tool selection mistakes
+- Create repeatable execution routines
+- Maintain consistency across planning/execution/verification phases
 
-## 패턴 매핑
+## Pattern Mapping
 
-> **중요**: 아래 테이블의 "OpenClaw 도구"는 모두 OpenClaw 공식 도구 인벤토리에 실제 존재하는 도구들이다.
+> **Important**: All "OpenClaw tools" in the table below are actual tools in the OpenClaw official tool inventory.
 
-| OmO Tool Pattern          | 의도                 | OpenClaw 도구 & 사용 패턴                                          |
-| ------------------------- | -------------------- | ------------------------------------------------------------------ |
-| `task/*` (todo-sync)      | 작업 상태 추적       | 파일 기반 할 일 관리: `write`로 `workspace/todos.md` 갱신          |
-| `lsp/*` (goto/references) | 코드 탐색/검증       | `exec` 도구로 린터/타입체커 실행 → 결과로 검증                     |
-| `interactive-bash`        | 장시간/상호작용 셸   | `exec`(`pty: true`) 또는 tmux 연동                                 |
-| `bash`                    | 원샷 명령            | `exec`(동기), `exec`(`background: true`) → `process`(`poll`)       |
-| `slashcommand`            | 명령 워크플로우 구동 | OpenClaw 스킬 `/ultrawork`, `/plan`, `/start_work` (슬래시 커맨드) |
-| `session-manager`         | 세션 탐색/재개       | `sessions_list`, `sessions_history`, `session_status`              |
-| `skill-mcp`               | 스킬 기반 도구 호출  | OpenClaw 스킬 시스템 (`read` → SKILL.md 참조)                      |
-| `look-at`                 | 멀티모달 분석        | `image` 도구 + Gemini CLI tmux 연동                                |
-| `background-task`         | 병렬 작업            | `exec`(`background: true`) → `process`(`poll`/`log`/`kill`)        |
-| `file-read/write/edit`    | 파일 조작            | `read`, `write`, `edit`, `apply_patch` (`group:fs`)                |
-| `web-search`              | 웹 검색              | `web_search`, `web_fetch` (`group:web`)                            |
-| `memory`                  | 지식 축적            | `memory_search`, `memory_get` (`group:memory`)                     |
-| `delegation`              | 서브에이전트 위임    | `sessions_spawn`(`task`, `agentId`, `model`)                       |
+| OmO Tool Pattern | Intent | OpenClaw Tool & Usage Pattern |
+|------------------|--------|-------------------------------|
+| `task/*` (todo-sync) | Task state tracking | File-based todo management: `write` to update `workspace/todos.md` |
+| `lsp/*` (goto/references) | Code exploration/verification | `exec` tool to run linters/typecheckers → verify with results |
+| `interactive-bash` | Long-running/interactive shell | `exec`(`pty: true`) or tmux integration |
+| `bash` | One-shot command | `exec`(sync), `exec`(`background: true`) → `process`(`poll`) |
+| `slashcommand` | Trigger command workflows | OpenClaw skills `/ultrawork`, `/plan`, `/start_work` (slash commands) |
+| `session-manager` | Session browse/resume | `sessions_list`, `sessions_history`, `session_status` |
+| `skill-mcp` | Skill-based tool calls | OpenClaw skill system (`read` → SKILL.md reference) |
+| `look-at` | Multimodal analysis | `image` tool + Gemini CLI tmux integration |
+| `background-task` | Parallel tasks | `exec`(`background: true`) → `process`(`poll`/`log`/`kill`) |
+| `file-read/write/edit` | File manipulation | `read`, `write`, `edit`, `apply_patch` (`group:fs`) |
+| `web-search` | Web search | `web_search`, `web_fetch` (`group:web`) |
+| `memory` | Knowledge accumulation | `memory_search`, `memory_get` (`group:memory`) |
+| `delegation` | Sub-agent delegation | `sessions_spawn`(`task`, `agentId`, `model`) |
 
-## OpenClaw Tool Groups 정리
+## OpenClaw Tool Groups
 
-| Group            | 포함 도구                                        | 활용                         |
-| ---------------- | ------------------------------------------------ | ---------------------------- |
-| `group:fs`       | read, write, edit, apply_patch                   | 파일 조작 전반               |
-| `group:runtime`  | exec, bash, process                              | 명령 실행 + 백그라운드 관리  |
-| `group:sessions` | sessions_list/history/send/spawn, session_status | 멀티 에이전트                |
-| `group:memory`   | memory_search, memory_get                        | 지식 검색 (저장은 파일 기반) |
-| `group:web`      | web_search, web_fetch                            | 웹 검색/페치                 |
-| `group:ui`       | browser, canvas                                  | 브라우저/UI                  |
+| Group | Included Tools | Usage |
+|-------|---------------|-------|
+| `group:fs` | read, write, edit, apply_patch | All file manipulation |
+| `group:runtime` | exec, bash, process | Command execution + background management |
+| `group:sessions` | sessions_list/history/send/spawn, session_status | Multi-agent |
+| `group:memory` | memory_search, memory_get | Knowledge search (storage is file-based) |
+| `group:web` | web_search, web_fetch | Web search/fetch |
+| `group:ui` | browser, canvas | Browser/UI |
 
-## 실행 절차
+## Execution Procedure
 
-### 1) 계획 단계
+### 1) Planning Phase
 
-1. 복잡 작업이면 `write`로 `workspace/todos.md` 생성
-2. 탐색은 `exec` + grep/find 우선
-3. 외부 의존성은 `web_search`/`web_fetch` 또는 librarian 에이전트 병행
+1. For complex tasks, create `workspace/todos.md` with `write`
+2. Use `exec` + grep/find for exploration
+3. For external dependencies, use `web_search`/`web_fetch` or librarian agent in parallel
 
-### 2) 구현 단계
+### 2) Implementation Phase
 
-1. 변경 전 `read` + `exec`(grep)로 영향도 파악
-2. 작은 단위로 `edit`/`apply_patch` 수정
-3. 필요 시 `sessions_spawn`로 전문 에이전트 위임
+1. Use `read` + `exec`(grep) to assess impact before changes
+2. Make small-unit `edit`/`apply_patch` modifications
+3. Delegate to specialized agents via `sessions_spawn` when needed
 
-### 3) 검증 단계
+### 3) Verification Phase
 
-1. `exec`로 린터/타입체커 실행
-2. `exec`로 관련 테스트/빌드 실행
-3. 실패 시 원인-기반 `edit` 후 재검증
+1. Run linters/typecheckers with `exec`
+2. Run relevant tests/builds with `exec`
+3. On failure, apply cause-based `edit` and re-verify
 
-### 4) 병렬 작업 관리
+### 4) Parallel Task Management
 
-1. 독립 탐색/리서치는 `exec`(`background: true`)로 병렬 실행
-2. `process`(`poll`/`log`)로 결과 수집
-3. 최종 응답 전 `process`(`kill`)로 정리
+1. Run independent exploration/research with `exec`(`background: true`)
+2. Collect results with `process`(`poll`/`log`)
+3. Clean up with `process`(`kill`) before final response
 
-## 금지/주의 사항
+## Prohibited / Caution
 
-- 구현 미요청 상태에서 코드 변경 금지
-- 검증 없는 완료 보고 금지
-- 장시간 TUI 작업은 `exec`(`pty: true`) 사용
-- 수동 추정으로 API/패턴 확정하지 않기 (검색/근거 필수)
+- Do not change code when implementation was not requested
+- Do not report completion without verification
+- Use `exec`(`pty: true`) for long-running TUI tasks
+- Do not confirm APIs/patterns by guessing — search/evidence required
 
-## 체크리스트
+## Checklist
 
-- [ ] Todo 상태가 `workspace/todos.md`에 실시간 반영되었는가
-- [ ] 사용한 도구가 OpenClaw 공식 도구 인벤토리에 존재하는가
-- [ ] 변경 후 `exec`로 test/build 근거가 있는가
-- [ ] 백그라운드 작업이 `process`(`kill`)로 정리되었는가
+- [ ] Todo state reflected in real-time in `workspace/todos.md`
+- [ ] All tools used exist in OpenClaw's official tool inventory
+- [ ] Evidence from `exec` test/build after changes
+- [ ] Background tasks cleaned up with `process`(`kill`)

--- a/plugin/workflows/start-work.md
+++ b/plugin/workflows/start-work.md
@@ -51,8 +51,8 @@ Execute an approved plan by delegating tasks to appropriate worker agents, track
    c. **Delegate the task** via `sessions_spawn`:
    ```
    sessions_spawn(
-     task="7요소 프롬프트 (TASK/OUTCOME/SKILLS/TOOLS/MUST DO/MUST NOT/CONTEXT)",
-     agentId="omoc_sisyphus",  # 또는 적합한 전문 에이전트
+     task="7-element prompt (TASK/OUTCOME/SKILLS/TOOLS/MUST DO/MUST NOT/CONTEXT)",
+     agentId="omoc_sisyphus",  # or appropriate specialized agent
      model="...",
      label="task-N-name"
    )
@@ -63,10 +63,10 @@ Execute an approved plan by delegating tasks to appropriate worker agents, track
    - For implementation-heavy tasks, route to OmO via tmux orchestration stack
    - Require execution evidence (changed files, test/build outputs) before marking done
 
-   d. **서브에이전트 완료 통지 → 즉시 행동** (강제)
-   - 완료 통지를 받으면 결과를 즉시 확인한다
-   - Acceptance criteria와 대조 검증한다
-   - 멈추지 않는다 — 다음 task로 즉시 진행한다
+   d. **Sub-agent completion notification → immediate action** (mandatory)
+   - Check results immediately upon receiving completion notification
+   - Verify against acceptance criteria
+   - Do not stop — proceed to next task immediately
 
    e. **Mark task as completed** in todo list
 
@@ -74,9 +74,9 @@ Execute an approved plan by delegating tasks to appropriate worker agents, track
 
 4. **Handle parallel tasks**
    - Tasks with no mutual dependencies can run in parallel
-   - Use multiple `sessions_spawn` simultaneously (각각 다른 `label`로 식별)
-   - 각 완료 통지마다 해당 결과를 즉시 수집/검증
-   - 모든 병렬 task 완료 후 의존 task 즉시 시작
+   - Use multiple `sessions_spawn` simultaneously (each with different `label`)
+   - Collect and verify results immediately from each completion notification
+   - Start dependent tasks immediately after all parallel tasks complete
 
 ### Phase 3: Error Handling
 

--- a/plugin/workflows/ultrawork.md
+++ b/plugin/workflows/ultrawork.md
@@ -36,21 +36,21 @@ When the user invokes `/ultrawork [task description]` or ultrawork mode is activ
    a. Mark step as in_progress in todo list
    b. Delegate coding execution to worker sessions:
       - sessions_spawn(task=..., agentId="omoc_sisyphus", model=..., label=...)
-      - 전문 에이전트가 필요하면 agentId로 지정 (omoc_oracle, omoc_explore 등)
-   c. 서브에이전트 완료 통지를 받으면 즉시:
-      - 결과를 확인한다 (멈추지 않는다!)
-      - 성공 기준과 대조 검증한다
-      - 검증 통과 → 즉시 다음 step 진행
-      - 검증 실패 → 재시도 (최대 3회)
+      - Use agentId for specialized agents when needed (omoc_oracle, omoc_explore, etc.)
+   c. On sub-agent completion notification, immediately:
+      - Check results (do NOT stop!)
+      - Verify against success criteria
+      - On pass → proceed to next step immediately
+      - On fail → retry (max 3 times)
    d. Record any learnings in wisdom notepad
    e. Mark step as completed
    f. If step fails after 3 retries:
       - Record issue and continue with next independent step
 
-⚠️ CONTINUATION RULE (강제):
-- 서브에이전트 완료 통지 = 행동 트리거. 절대 멈추지 않는다.
-- 모든 step이 완료될 때까지 자동으로 다음 step을 진행한다.
-- 사용자 확인이 필요한 경우는 plan에 명시된 경우만 해당한다.
+⚠️ CONTINUATION RULE (mandatory):
+- Sub-agent completion notification = action trigger. Never stop.
+- Automatically proceed to next step until all steps are complete.
+- User confirmation is only needed when explicitly specified in the plan.
 ```
 
 ### Phase 3: Verification

--- a/skills/delegation-prompt.md
+++ b/skills/delegation-prompt.md
@@ -1,97 +1,158 @@
 ---
 name: delegation-prompt
-description: sessions_spawn 기반 서브에이전트 위임 가이드. 7요소 프롬프트 + sessions_spawn 호출 패턴.
+description: Sub-agent delegation guide using sessions_spawn. 7-element prompt template + token-efficient delegation patterns.
 ---
 
 # Delegation Prompt + sessions_spawn Guide
 
-OmO의 핵심 컨셉은 **서브에이전트 활용**이다. oh-my-openclaw에서는 OpenClaw의 `sessions_spawn`을 사용하여 실제 서브 에이전트를 생성한다.
+The core concept of OmOC is **sub-agent utilization**. oh-my-openclaw uses OpenClaw's `sessions_spawn` to create real sub-agent sessions.
 
-## sessions_spawn 사용법
+## Token Efficiency Principle (Primary Rule)
+
+**The main session runs the most expensive model.** Every token of raw data injected into the main session costs disproportionately more than processing it in a sub-agent.
+
+### The Token Efficiency Rule
+
+> **Any task that would inject raw data (file contents, grep output, images, PDFs, logs) into the main session MUST be delegated to a sub-agent.** The main session should only receive condensed summaries.
+
+This replaces the old "5-minute rule." The decision criterion is **not time** but **token cost**:
+
+- Reading 3 files to find a pattern → **Delegate** (raw file content stays in sub-agent)
+- Grepping across a codebase → **Delegate** (search results stay in sub-agent)
+- Analyzing a PDF/image → **Delegate** (multimodal data stays in sub-agent)
+- Making a yes/no decision from known context → **Direct** (no raw data needed)
+- Writing a 2-line response to user → **Direct** (no raw data needed)
+
+## sessions_spawn Usage
 
 ```
 sessions_spawn(
-  task="...",           # 7요소 프롬프트 (아래 참조)
-  mode="run",           # "run" (일회성) | "session" (영구)
-  model="...",          # 카테고리별 모델 (아래 표 참조)
-  agentId="...",        # 특정 에이전트 지정 (선택 — omoc_prometheus, omoc_sisyphus 등)
-  label="...",          # 식별용 라벨 (선택)
-  thread=true           # Discord 스레드로 결과 전달 (선택)
+  task="...",           # 7-element prompt (see below)
+  mode="run",           # "run" (one-shot) | "session" (persistent)
+  model="...",          # Category-based model (see table below)
+  agentId="...",        # Specific agent (optional — omoc_prometheus, omoc_sisyphus, etc.)
+  label="...",          # Identification label (optional)
+  thread=true           # Deliver results via Discord thread (optional)
 )
 ```
 
-### agentId로 전문 에이전트 지정
+### Specifying Agents via agentId
 
-`agentId`를 명시하면 해당 에이전트의 페르소나/권한/모델이 자동 적용된다:
+When `agentId` is specified, the agent's persona/permissions/model are auto-applied:
 
-| agentId | 역할 | 권한 |
-|---------|------|------|
-| `omoc_prometheus` | 전략 기획 | read-only (코드 수정 불가) |
-| `omoc_atlas` | 오케스트레이션 | read-only (코드 수정 불가) |
-| `omoc_sisyphus` | 구현 워커 | full (코드 수정 가능) |
-| `omoc_hephaestus` | 딥 구현 | full (코드 수정 가능) |
-| `omoc_oracle` | 아키텍처 컨설팅 | read-only |
-| `omoc_explore` | 코드 탐색 | read-only |
-| `omoc_librarian` | 문서 리서치 | read-only |
-| `omoc_metis` | 갭 분석 | read-only |
-| `omoc_momus` | 플랜 리뷰 | read-only |
+| agentId | Role | Permissions |
+|---------|------|-------------|
+| `omoc_prometheus` | Strategic planning | read-only |
+| `omoc_atlas` | Orchestration | full |
+| `omoc_sisyphus` | Implementation worker | full |
+| `omoc_hephaestus` | Deep implementation | full |
+| `omoc_oracle` | Architecture consulting | read-only |
+| `omoc_explore` | Codebase search | read-only |
+| `omoc_librarian` | Documentation research | read-only |
+| `omoc_metis` | Gap analysis | read-only |
+| `omoc_momus` | Plan review | read-only |
 
-`agentId` 생략 시 기본 에이전트가 `model`에 맞춰 실행된다.
+When `agentId` is omitted, the default agent runs with the specified `model`.
 
-## 카테고리별 모델 매핑
+## Category-to-Model Mapping
 
-| 카테고리 | 모델 | 용도 |
-|---------|------|------|
-| quick | claude-sonnet-4-6 | 간단한 수정, 파일 탐색, 검색 |
-| deep | claude-opus-4-6-thinking | 복잡한 리팩토링, 분석, 자율 작업 |
-| ultrabrain | gpt-5.3-codex | 깊은 추론, 아키텍처 설계 |
-| visual-engineering | gemini-3.1-pro | 프론트엔드, UI/UX, 디자인 |
-| writing | claude-sonnet-4-6 | 문서, 기술 글쓰기 |
+| Category | Model | Use Case |
+|----------|-------|----------|
+| quick | claude-sonnet-4-6 | Simple fixes, file search, grep, exploration |
+| deep | claude-opus-4-6-thinking | Complex refactoring, analysis, autonomous work |
+| ultrabrain | gpt-5.3-codex | Deep reasoning, architecture design |
+| visual-engineering | gemini-3.1-pro | Frontend, UI/UX, design |
+| writing | claude-sonnet-4-6 | Documentation, technical writing |
 
-## 위임 결정 기준
+## Delegation Decision Criteria
 
-기본 원칙: **구현/수정/리팩토링/테스트/빌드 관련 작업은 기본적으로 sessions_spawn 위임이 필수**.
+### MUST Delegate (Token Efficiency)
 
-### sessions_spawn을 쓸 때 (서브에이전트)
-- **병렬 가능한 독립 작업** (여러 파일 검증, 여러 리포 탐색)
-- **시간이 오래 걸리는 작업** (대규모 리팩토링, 전체 코드 분석)
-- **다른 모델이 더 적합한 작업** (추론→gpt-5.3, 비주얼→gemini)
-- **background=true로 비동기 실행 후 결과 수신**
+- **Any file reading task** — raw file contents must NOT enter the main session
+- **Codebase search/grep** — search results stay in sub-agent, return summary only
+- **PDF/image/video analysis** — multimodal data stays in sub-agent
+- **Multiple independent tasks** — parallel sub-agents for efficiency
+- **Long-running tasks** — large refactoring, full codebase analysis
+- **Tasks better suited to another model** — reasoning→gpt-5.3, visual→gemini
+- **Implementation/modification/refactoring/testing/build tasks** — always delegate
 
-### 직접 처리할 때 (spawn 불필요)
-- 순수 설명/요약/의사결정만 필요한 경우 (파일 변경 없음)
-- 사용자 확인 질문에 대한 짧은 응답
-- 플랜 문서 작성 자체 (구현 실행 전 단계)
+### Direct Handling (No Spawn Needed)
 
-### OmO 구현 위임 (강제)
+- Pure explanation/summary/decision-making (no file changes, no raw data)
+- Short responses to user confirmation questions
+- Plan document writing itself (pre-execution phase)
+- Decisions based on already-known context
 
-- 코드 변경이 필요한 작업은 `opencode-controller` + `tmux` + `tmux-agents` 경로로 위임한다.
-- 구현 단계에서 "직접 처리"는 예외가 아니라 **금지**다.
-- 최소 1개의 실행 세션을 생성하고 결과를 수집/검증한다.
+### OmO Implementation Delegation (Mandatory)
 
-## 7 Required Elements (프롬프트 품질 = 위임 품질)
+- Tasks requiring code changes MUST be delegated via `opencode-controller` + `tmux` + `tmux-agents`.
+- "Direct handling" during implementation is not an exception — it is **forbidden**.
+- At minimum, create one execution session and collect/verify results.
 
-1. **TASK**: 단일 원자 작업을 명확히 지시
-2. **EXPECTED OUTCOME**: 산출물과 성공 기준을 구체화
-3. **REQUIRED SKILLS**: 필요한 스킬 목록 명시
-4. **REQUIRED TOOLS**: 사용 가능한 도구 화이트리스트
-5. **MUST DO**: 반드시 수행할 세부 요구사항
-6. **MUST NOT DO**: 금지사항 (범위 확장, 파일 수정 금지 등)
-7. **CONTEXT**: 경로, 제약, 기존 패턴, 다운스트림 목적
+## Compressed Output Format (Mandatory for Read-Only Agents)
 
-## 실행 예시
+All read-only sub-agents (explore, librarian, oracle, metis, momus) MUST return results in this compressed format. This ensures the main session receives only actionable summaries, not raw data.
 
-### 예시 1: 코드 분석 (deep, background)
+```xml
+<results>
+<files>
+- /absolute/path/to/file1.ts — [why relevant]
+- /absolute/path/to/file2.ts — [why relevant]
+</files>
+
+<answer>
+[Direct answer to the actual need — not just a file list]
+[Address the underlying intent, not just the literal request]
+</answer>
+
+<next_steps>
+[What to do with this information]
+[Or: "Ready to proceed — no follow-up needed"]
+</next_steps>
+</results>
+```
+
+### Why This Format?
+
+- **Caller gets actionable intelligence** without parsing verbose output
+- **Token cost stays in the sub-agent** — raw grep/read output never reaches main session
+- **No follow-up needed** — a good `<results>` block eliminates "but where exactly?" questions
+
+## 7 Required Elements (Prompt Quality = Delegation Quality)
+
+1. **TASK**: Clear, atomic task instruction
+2. **EXPECTED OUTCOME**: Deliverables and success criteria
+3. **REQUIRED SKILLS**: List of needed skills
+4. **REQUIRED TOOLS**: Tool whitelist
+5. **MUST DO**: Mandatory detailed requirements
+6. **MUST NOT DO**: Prohibitions (scope expansion, file modification, etc.)
+7. **CONTEXT**: Paths, constraints, existing patterns, downstream purpose
+
+### Output Compression Directive (Add to MUST DO)
+
+When delegating to read-only agents, always include:
+
+```
+MUST DO:
+- Return results in <results><files><answer><next_steps> format
+- Compress all findings into actionable summary — do NOT dump raw file contents
+- Use absolute paths only
+```
+
+## Examples
+
+### Example 1: Code Analysis (deep, background)
 ```
 sessions_spawn(
   task="""
-  1) TASK: /home/happycastle/Projects/my-app/src/ 디렉토리의 테스트 커버리지 분석
-  2) EXPECTED OUTCOME: 테스트 없는 파일 목록 + 우선순위별 테스트 작성 계획
+  1) TASK: Analyze test coverage for /home/happycastle/Projects/my-app/src/
+  2) EXPECTED OUTCOME: List of untested files + prioritized test writing plan
   3) REQUIRED SKILLS: none
   4) REQUIRED TOOLS: read, exec (jest --coverage)
-  5) MUST DO: 각 파일의 복잡도와 중요도 평가 포함
-  6) MUST NOT DO: 테스트 파일 직접 작성하지 말 것
-  7) CONTEXT: Jest + TypeScript 프로젝트, src/utils/는 가장 중요
+  5) MUST DO: Include complexity and importance assessment for each file.
+     Return results in <results><files><answer><next_steps> format.
+  6) MUST NOT DO: Do not write test files directly
+  7) CONTEXT: Jest + TypeScript project, src/utils/ is highest priority
   """,
   mode="run",
   model="claude-opus-4-6-thinking",
@@ -99,17 +160,18 @@ sessions_spawn(
 )
 ```
 
-### 예시 2: 웹 리서치 (quick, background)
+### Example 2: Web Research (quick, background)
 ```
 sessions_spawn(
   task="""
-  1) TASK: Next.js 15의 Server Actions 변경사항 조사
-  2) EXPECTED OUTCOME: 주요 변경점 요약 + 마이그레이션 가이드
+  1) TASK: Research Next.js 15 Server Actions changes
+  2) EXPECTED OUTCOME: Key changes summary + migration guide
   3) REQUIRED SKILLS: web-search
   4) REQUIRED TOOLS: web_fetch, exec (mcporter)
-  5) MUST DO: 공식 문서 + 커뮤니티 피드백 모두 확인
-  6) MUST NOT DO: 코드 수정하지 말 것
-  7) CONTEXT: 현재 Next.js 14 사용 중, 업그레이드 검토
+  5) MUST DO: Check both official docs and community feedback.
+     Return results in <results><files><answer><next_steps> format.
+  6) MUST NOT DO: Do not modify code
+  7) CONTEXT: Currently using Next.js 14, evaluating upgrade
   """,
   mode="run",
   model="claude-sonnet-4-6",
@@ -117,68 +179,94 @@ sessions_spawn(
 )
 ```
 
-### 예시 3: 병렬 작업 (여러 spawn 동시)
+### Example 3: Parallel Tasks (multiple spawns)
 ```
-# 동시에 3개 서브에이전트 실행
-sessions_spawn(task="파일 A 리팩토링...", mode="run", model="claude-opus-4-6-thinking", label="refactor-a")
-sessions_spawn(task="파일 B 리팩토링...", mode="run", model="claude-opus-4-6-thinking", label="refactor-b")
-sessions_spawn(task="테스트 작성...", mode="run", model="claude-sonnet-4-6", label="write-tests")
+# 3 sub-agents running simultaneously
+sessions_spawn(task="Refactor file A...", mode="run", model="claude-opus-4-6-thinking", label="refactor-a")
+sessions_spawn(task="Refactor file B...", mode="run", model="claude-opus-4-6-thinking", label="refactor-b")
+sessions_spawn(task="Write tests...", mode="run", model="claude-sonnet-4-6", label="write-tests")
 ```
 
-## omoc_delegate와의 관계
+## Relationship with omoc_delegate
 
-`omoc_delegate` 도구는 카테고리 → 모델 매핑만 해준다. 실제 서브에이전트 생성은 반드시 `sessions_spawn`을 호출해야 한다.
+`omoc_delegate` only handles category → model mapping. Actual sub-agent creation requires calling `sessions_spawn`.
 
-**올바른 흐름:**
-1. `omoc_delegate`로 카테고리/모델 확인 (선택적)
-2. `sessions_spawn`으로 실제 서브에이전트 생성
-3. 완료 시 자동 통지 수신 (push-based)
+**Correct flow:**
+1. Use `omoc_delegate` to check category/model (optional)
+2. Use `sessions_spawn` to create the actual sub-agent
+3. Receive automatic completion notification (push-based)
 
-**절대 하지 말 것:**
-- `subagents list`를 루프로 폴링하지 말 것 — 결과는 자동으로 돌아옴
-- spawn 후 즉시 결과를 기대하지 말 것 — 비동기 실행
+**Never do this:**
+- Do NOT poll `subagents list` in a loop — results arrive automatically
+- Do NOT expect immediate results after spawn — execution is asynchronous
+
+## Sub-Agent Routing Metadata
+
+When choosing whether to delegate, use these heuristics:
+
+### Explore Agent
+- **Use when**: Multiple search angles needed, unfamiliar module structure, cross-layer pattern discovery
+- **Avoid when**: You know exactly what to search, single keyword suffices, known file location
+
+### Librarian Agent
+- **Use when**: External library questions, "How do I use [X]?", unfamiliar packages, best practice lookups
+- **Avoid when**: Internal code only, no external dependencies involved
+
+### Oracle Agent
+- **Use when**: Architecture tradeoff decisions, complex debugging after repeated failures, design review
+- **Avoid when**: Simple implementation, no architectural implications
+
+### Metis Agent
+- **Use when**: Ambiguous task needs intent classification, risk of scope creep, pre-planning gap analysis
+- **Avoid when**: Task is clear and well-defined, simple implementation
+
+### Momus Agent
+- **Use when**: Plan needs executability review, catching critical blockers before implementation
+- **Avoid when**: Plan is simple enough to self-review, single-step task
 
 ## Quality Checklist
 
-- [ ] 결과 검증 기준이 측정 가능하다
-- [ ] 입력 경로/범위가 명시되어 있다
-- [ ] 금지사항이 모호하지 않다
-- [ ] 실패 시 재시도/보고 방식이 정의되어 있다
-- [ ] 적절한 카테고리/모델을 선택했다
-- [ ] mode가 맞다 (run=일회성, session=영구)
+- [ ] Success criteria are measurable
+- [ ] Input paths/scope are specified
+- [ ] Prohibitions are unambiguous
+- [ ] Failure retry/reporting strategy is defined
+- [ ] Correct category/model selected
+- [ ] Mode is correct (run=one-shot, session=persistent)
+- [ ] Output compression directive included for read-only agents
 
-## 서브에이전트 완료 후 행동 (강제)
+## Post-Completion Behavior (Mandatory)
 
-서브에이전트 완료 통지("✅ Subagent finished")는 **FYI가 아니라 행동 트리거**다.
+Sub-agent completion notifications ("✅ Subagent finished") are **action triggers, not FYI messages**.
 
-### 완료 통지를 받으면 반드시:
+### On receiving a completion notification:
 
-1. **결과 확인** — 서브에이전트가 산출한 결과를 즉시 읽는다
-2. **성공 기준 대조** — 위임 시 명시한 EXPECTED OUTCOME과 비교 검증한다
-3. **다음 단계 실행** — 검증 통과 시 즉시 다음 phase/step을 진행한다
-4. **실패 시 재시도** — 검증 실패 시 같은 에이전트로 재시도 (최대 3회) 또는 에스컬레이션
-5. **멈추지 않는다** — 모든 phase가 완료될 때까지 절대 멈추지 않는다
+1. **Check results** — immediately read the sub-agent's output
+2. **Verify against criteria** — compare with the delegated EXPECTED OUTCOME
+3. **Execute next step** — proceed to the next phase/step upon verification
+4. **Retry on failure** — re-delegate to the same agent (max 3 retries) or escalate
+5. **Never stop** — continue until all phases are complete
 
-### 금지사항:
+### Prohibited:
 
-- ❌ 완료 통지를 받고 아무 행동 없이 멈추기
-- ❌ "완료되었습니다"만 보고하고 결과를 확인하지 않기
-- ❌ 다음 phase가 있는데 사용자 확인을 기다리기 (자동 진행이 기본)
-- ❌ 서브에이전트 결과를 무시하고 직접 다시 작업하기
+- ❌ Receiving a completion notification and doing nothing
+- ❌ Reporting "done" without checking results
+- ❌ Waiting for user confirmation when the next phase is ready (auto-proceed is default)
+- ❌ Ignoring sub-agent results and redoing the work directly
 
-### 병렬 서브에이전트인 경우:
+### For parallel sub-agents:
 
-- 각 완료 통지마다 해당 결과를 수집한다
-- 모든 병렬 에이전트가 완료되면 의존 phase를 즉시 시작한다
-- 일부만 완료된 상태에서는 독립적인 다음 작업을 먼저 진행한다
+- Collect results from each completion notification
+- Start dependent phases immediately when all parallel agents finish
+- Proceed with independent next tasks while waiting for remaining agents
 
 ## Anti-Patterns
 
-- "적당히", "알아서" 같은 모호한 지시
-- 도구 무제한 허용
-- 컨텍스트 없는 대규모 요청
-- 기대 산출물이 없는 위임
-- spawn 후 poll 루프로 결과 대기
-- 모든 작업을 직접 처리 (서브에이전트 미활용)
-- 구현 작업인데 sessions_spawn 없이 직접 코드 수정
-- **완료 통지 후 멈추기 (가장 흔한 실패 패턴)**
+- Vague instructions like "figure it out" or "do your best"
+- Unlimited tool access
+- Large requests without context
+- Delegating without expected deliverables
+- Polling loops after spawn
+- Handling everything directly (not using sub-agents)
+- Modifying code directly when sessions_spawn should be used
+- **Stopping after completion notification (most common failure pattern)**
+- **Injecting raw file contents into the main session instead of delegating**

--- a/skills/gemini-look-at.md
+++ b/skills/gemini-look-at.md
@@ -1,160 +1,160 @@
 ---
 name: gemini-look-at
-description: Gemini CLI 기반 멀티모달 분석 스킬. PDF, 이미지, 스크린샷, 다이어그램을 Gemini의 네이티브 멀티모달 능력으로 분석한다. tmux gemini 세션을 통해 실행.
+description: Multimodal analysis skill using Gemini CLI. Analyzes PDFs, images, screenshots, and diagrams via Gemini's native multimodal capabilities. Runs through tmux gemini session.
 ---
 # Gemini Look-At — Multimodal Analysis via Gemini CLI
 
-OmO의 `look-at` 도구를 Gemini CLI + tmux로 재구현한 스킬.
-OpenClaw의 `read` 도구는 이미지를 첨부로 보내줄 수 있지만, **PDF는 읽을 수 없고**, Gemini CLI는 PDF/이미지/비디오를 네이티브로 분석할 수 있다.
+Re-implementation of OmO's `look-at` tool using Gemini CLI + tmux.
+OpenClaw's `read` tool can send images as attachments, but **cannot read PDFs natively**. Gemini CLI can analyze PDF/image/video natively.
 
-## 언제 사용하는가
+## When to Use
 
-- **PDF 분석** — 레이아웃, 디자인, 콘텐츠 품질 평가
-- **이미지/스크린샷 분석** — UI 리뷰, 버그 확인, 디자인 피드백
-- **다이어그램 해석** — 아키텍처, 플로우차트, ER 다이어그램 분석
-- **멀티 파일 비교** — 두 PDF/이미지를 동시에 비교
-- **OCR + 해석** — 스크린샷에서 텍스트 추출 + 의미 분석
+- **PDF analysis** — layout, design, content quality assessment
+- **Image/screenshot analysis** — UI review, bug verification, design feedback
+- **Diagram interpretation** — architecture, flowchart, ER diagram analysis
+- **Multi-file comparison** — compare two PDFs/images side by side
+- **OCR + interpretation** — extract text from screenshots + semantic analysis
 
-## Gemini CLI 기본 사용법
+## Gemini CLI Basics
 
 ```bash
-# 빠른 시작
-gemini "질문..."
+# Quick start
+gemini "your question..."
 
-# 모델 지정
-gemini --model <name> "프롬프트..."
+# Specify model
+gemini --model <name> "prompt..."
 
-# JSON 형식 출력
-gemini --output-format json "JSON 반환"
+# JSON output format
+gemini --output-format json "return JSON"
 
-# 확장(extensions) 목록 확인
+# List extensions
 gemini --list-extensions
 ```
 
-- 첫 실행 시 인터랙티브 로그인/인증이 필요하다.
-- `--yolo` 플래그는 사용하지 않는다.
+- First run requires interactive login/authentication.
+- Do NOT use the `--yolo` flag.
 
-## 실행 방법
+## Execution Methods
 
-### 방법 1: tmux gemini 세션 (권장)
+### Method 1: tmux gemini session (recommended)
 
-tmux `gemini` 세션이 이미 인증되어 있으므로 안정적.
+The tmux `gemini` session is already authenticated and stable.
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 SESSION="gemini"
 
-# 단일 파일 분석
+# Single file analysis
 tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- \
-  "gemini -m gemini-2.5-flash --prompt '이 파일을 분석해줘. 레이아웃, 디자인, 콘텐츠 품질을 평가하고 개선점을 제안해.' -f /path/to/file.pdf -o text" \
+  "gemini -m gemini-2.5-flash --prompt 'Analyze this file. Evaluate layout, design, content quality, and suggest improvements.' -f /path/to/file.pdf -o text" \
   && sleep 0.1 && tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 Enter
 
-# 결과 확인 (10-30초 대기 후)
+# Check results (wait 10-30 seconds)
 sleep 15
 tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
 ```
 
-### 방법 2: 결과를 파일로 저장
+### Method 2: Save output to file
 
-분석 결과가 길 때는 파일로 리다이렉트:
+When analysis output is long, redirect to a file:
 
 ```bash
 tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- \
-  "gemini -m gemini-2.5-flash --prompt '상세 분석' -f /path/to/file.pdf -o text > /tmp/gemini-analysis.md 2>&1" \
+  "gemini -m gemini-2.5-flash --prompt 'Detailed analysis' -f /path/to/file.pdf -o text > /tmp/gemini-analysis.md 2>&1" \
   && sleep 0.1 && tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 Enter
 
-# 결과 파일 읽기
+# Read result file
 sleep 20
 cat /tmp/gemini-analysis.md
 ```
 
-### 방법 3: 여러 파일 동시 분석
+### Method 3: Multi-file analysis
 
 ```bash
 tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -l -- \
-  "gemini -m gemini-2.5-flash --prompt '두 파일을 비교해줘' -f /path/to/before.png -f /path/to/after.png -o text" \
+  "gemini -m gemini-2.5-flash --prompt 'Compare these two files' -f /path/to/before.png -f /path/to/after.png -o text" \
   && sleep 0.1 && tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 Enter
 ```
 
-## 분석 패턴별 프롬프트
+## Analysis Prompt Templates
 
-### PDF 레이아웃/디자인 리뷰
+### PDF Layout/Design Review
 ```
-이 PDF의 레이아웃, 줄넘김, 디자인을 평가해줘. 
-부자연스러운 부분이 있으면 구체적으로 알려줘.
-특히: 여백, 폰트 크기, 줄간격, 페이지 나눔, 표/이미지 배치를 체크해.
-```
-
-### 스크린샷 UI 리뷰
-```
-이 웹 UI 스크린샷을 분석해줘.
-1. 레이아웃 정렬과 간격 일관성
-2. 타이포그래피 계층 구조
-3. 색상 대비 및 접근성
-4. 인터랙티브 요소의 가시성
-5. 전체적인 디자인 품질 (1-10 점수)
-개선 제안을 구체적으로 해줘.
+Evaluate this PDF's layout, line breaks, and design.
+Point out any unnatural areas specifically.
+Check: margins, font sizes, line spacing, page breaks, table/image placement.
 ```
 
-### 아키텍처 다이어그램 해석
+### Screenshot UI Review
 ```
-이 아키텍처 다이어그램을 분석해줘.
-- 각 컴포넌트의 역할을 식별
-- 데이터 흐름 방향을 설명
-- 잠재적 병목점이나 단일 장애점을 식별
-- 개선 제안
-```
-
-### Before/After 비교
-```
-이 두 이미지를 비교해줘.
-- 바뀐 부분을 구체적으로 나열
-- 개선된 점과 퇴보한 점을 구분
-- 추가 개선 제안
+Analyze this web UI screenshot.
+1. Layout alignment and spacing consistency
+2. Typography hierarchy
+3. Color contrast and accessibility
+4. Interactive element visibility
+5. Overall design quality (1-10 score)
+Provide specific improvement suggestions.
 ```
 
-### 에러 스크린샷 디버깅
+### Architecture Diagram Interpretation
 ```
-이 에러 스크린샷을 분석해줘.
-- 에러 메시지를 정확히 읽어줘
-- 가능한 원인을 추정
-- 해결 방법을 제안
+Analyze this architecture diagram.
+- Identify each component's role
+- Describe data flow direction
+- Identify potential bottlenecks or single points of failure
+- Suggest improvements
 ```
 
-## 모델 선택 가이드
+### Before/After Comparison
+```
+Compare these two images.
+- List specific changes
+- Distinguish improvements from regressions
+- Suggest additional improvements
+```
 
-| 용도 | 추천 모델 | 이유 |
-|------|-----------|------|
-| 빠른 확인 | `gemini-2.5-flash` | 빠름, 충분한 멀티모달 능력 |
-| 상세 분석 | `gemini-2.5-pro` | 더 깊은 분석, 긴 콘텐츠 |
-| 최고 품질 | `gemini-3.1-pro` | 최신 모델, 최상의 멀티모달 |
+### Error Screenshot Debugging
+```
+Analyze this error screenshot.
+- Read the error message exactly
+- Estimate possible causes
+- Suggest solutions
+```
+
+## Model Selection Guide
+
+| Purpose | Recommended Model | Reason |
+|---------|-------------------|--------|
+| Quick check | `gemini-2.5-flash` | Fast, sufficient multimodal ability |
+| Detailed analysis | `gemini-2.5-pro` | Deeper analysis, long content |
+| Highest quality | `gemini-3.1-pro` | Latest model, best multimodal |
 
 ## OpenClaw read vs Gemini CLI
 
-| 기능 | OpenClaw `read` | Gemini CLI |
-|------|----------------|------------|
-| 이미지 (PNG/JPG) | ✅ 첨부로 전송 | ✅ 네이티브 분석 |
-| PDF | ❌ 텍스트만 | ✅ 레이아웃 포함 분석 |
-| 비디오 | ❌ | ✅ 프레임 분석 |
-| 여러 파일 동시 | ❌ 하나씩 | ✅ `-f` 여러 개 |
-| 인증 | 불필요 | tmux 세션 필요 |
+| Feature | OpenClaw `read` | Gemini CLI |
+|---------|----------------|------------|
+| Images (PNG/JPG) | ✅ Sent as attachment | ✅ Native analysis |
+| PDF | ❌ Text only | ✅ Layout-aware analysis |
+| Video | ❌ | ✅ Frame analysis |
+| Multiple files | ❌ One at a time | ✅ Multiple `-f` flags |
+| Authentication | Not needed | tmux session required |
 
-## 워크플로우: OpenCode + Gemini CLI 연계
+## Workflow: OpenCode + Gemini CLI Integration
 
-코딩 작업 중 시각적 확인이 필요할 때:
+When visual verification is needed during coding:
 
 ```
-1. OpenCode (tmux opencode 세션)에서 코드 작성/수정
-2. 빌드/렌더링 결과물 생성 (PDF, 스크린샷 등)
-3. Gemini CLI (tmux gemini 세션)로 결과물 시각적 품질 검증
-4. 문제 발견 시 → 다시 OpenCode로 돌아가서 수정
-5. 반복 (결과물 만족할 때까지)
+1. Write/modify code in OpenCode (tmux opencode session)
+2. Generate build/render output (PDF, screenshot, etc.)
+3. Verify visual quality with Gemini CLI (tmux gemini session)
+4. If issues found → return to OpenCode to fix
+5. Repeat until output is satisfactory
 ```
 
-## 주의사항
+## Important Notes
 
-- tmux `gemini` 세션이 반드시 실행 중이어야 함 (인증 상태 유지)
-- `capture-pane`으로 결과 확인 시 출력이 잘리면 `-S -500` 등으로 줄 수 늘리기
-- 파일 경로는 절대 경로 사용
-- 응답 대기: PDF 크기에 따라 10-60초 소요 가능
-- `--yolo` 플래그 사용 금지 (안전성)
+- The tmux `gemini` session MUST be running (maintains auth state)
+- If `capture-pane` output is truncated, increase lines with `-S -500`
+- Use absolute file paths
+- Response wait time: 10-60 seconds depending on PDF size
+- Do NOT use `--yolo` flag (safety)

--- a/skills/multimodal-analysis.md
+++ b/skills/multimodal-analysis.md
@@ -5,35 +5,35 @@ description: Multimodal file analysis skill for PDFs, images, and technical diag
 
 # Multimodal Analysis - File Analysis Skill
 
-OmO `look-at` 도구 패턴을 기반으로, 문서/이미지/다이어그램 분석을 표준화한다.
+Standardizes document/image/diagram analysis based on OmO's `look-at` tool pattern.
 
 ## Source Pattern (OmO)
 
-- `look-at`는 파일 경로 + 분석 목표(goal)를 받아 멀티모달 해석 수행
-- 핵심 입력은 단순하다: **무엇을 볼지** + **무엇을 추출할지**
+- `look-at` takes a file path + analysis goal and performs multimodal interpretation
+- Core input is simple: **what to look at** + **what to extract**
 
 ## Supported Inputs
 
-- PDF 문서
-- 일반 이미지(PNG/JPG/WebP)
-- 기술 다이어그램(architecture/flow/UML/ER)
+- PDF documents
+- Standard images (PNG/JPG/WebP)
+- Technical diagrams (architecture/flow/UML/ER)
 
 ## Analysis Patterns
 
 ### 1) PDF Analysis
 
-- 목표 예시: 요약, 정책/요건 추출, 변경점 비교
-- 출력: 핵심 항목 bullet + 필요한 경우 구조화 목록
+- Example goals: summarize, extract policies/requirements, compare changes
+- Output: key items as bullets + structured list when needed
 
 ### 2) Image Analysis
 
-- 목표 예시: 화면 구성요소 식별, 텍스트/라벨 추출, 상태 비교
-- 출력: 영역별 관찰 + actionable insight
+- Example goals: identify UI components, extract text/labels, compare states
+- Output: per-region observations + actionable insights
 
 ### 3) Diagram Analysis
 
-- 목표 예시: 컴포넌트 관계, 데이터 흐름, 병목/리스크 파악
-- 출력: 노드/엣지 해석 + 개선 포인트
+- Example goals: component relationships, data flow, bottleneck/risk identification
+- Output: node/edge interpretation + improvement points
 
 ## Prompt Template
 
@@ -46,13 +46,13 @@ Output: <summary|table|checklist>
 
 ## Recommended Workflow
 
-1. 목표를 1문장으로 명확화
-2. 파일 유형에 맞는 패턴 선택
-3. 분석 결과를 실행 가능한 액션으로 변환
-4. 불확실성은 "추정"으로 명시
+1. Clarify the goal in one sentence
+2. Select the appropriate pattern for the file type
+3. Convert analysis results into actionable items
+4. Mark uncertainty as "estimated" explicitly
 
 ## Guardrails
 
-- 파일 내용이 불명확하면 단정하지 않는다
-- OCR/시각 해석 결과는 근거와 함께 제시
-- 원문 인용이 필요하면 짧게, 과도한 복붙 금지
+- Do not make assertions when file content is unclear
+- Present OCR/visual interpretation results with supporting evidence
+- Keep source quotes brief; no excessive copy-paste

--- a/skills/opencode-controller.md
+++ b/skills/opencode-controller.md
@@ -1,61 +1,61 @@
 ---
 name: opencode-controller
-description: tmux의 OpenCode 세션을 제어한다. 세션 관리, 모델 선택, 에이전트 전환(Plan/Build), OmO 위임 패턴을 포함.
+description: Controls the OpenCode session in tmux. Includes session management, model selection, agent switching (Plan/Build), and OmO delegation patterns.
 ---
 
-# opencode-controller — OpenCode 세션 제어
+# opencode-controller — OpenCode Session Control
 
-OpenClaw는 직접 코드를 쓰는 실행기가 아니라, OpenCode에 작업을 위임해 결과를 수집/검증하는 오케스트레이터다.
+OpenClaw is not a code executor — it delegates work to OpenCode and collects/verifies results as an orchestrator.
 
-## 핵심 원칙
+## Core Principles
 
-- OpenClaw가 직접 코드를 작성하지 않는다
-- 코딩 작업은 tmux `opencode` 세션으로 위임한다
-- OpenClaw는 작업 분해, 지시, 모니터링, 결과 검증을 담당한다
+- OpenClaw does not write code directly
+- Coding tasks are delegated to the tmux `opencode` session
+- OpenClaw handles task decomposition, instruction, monitoring, and result verification
 
-## Pre-flight 체크
+## Pre-flight Check
 
-### 1) Provider/모델 선택
+### 1) Provider/Model Selection
 
-- 작업 난이도에 따라 OpenCode 모델 선택(quick/deep/ultrabrain)
-- 고난도 작업은 고성능 모델 우선
+- Select OpenCode model based on task difficulty (quick/deep/ultrabrain)
+- High-difficulty tasks should prefer high-performance models
 
-### 2) 인증 상태
+### 2) Authentication State
 
-- OpenCode CLI 제공자 인증이 완료되어 있어야 함
-- 인증 만료 시 세션 내에서 재로그인 후 재시도
+- OpenCode CLI provider authentication must be completed
+- If auth expires, re-login within the session and retry
 
-### 3) tmux 세션 확인
+### 3) tmux Session Check
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 tmux -S "$SOCKET" has-session -t opencode
 ```
 
-## 세션 관리
+## Session Management
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 
-# 세션 생성
+# Create session
 tmux -S "$SOCKET" new -d -s opencode -n main
 
-# 세션 상태
+# Session status
 tmux -S "$SOCKET" list-sessions
 
-# 세션 출력 확인
+# Check session output
 tmux -S "$SOCKET" capture-pane -p -J -t opencode:0.0 -S -200
 ```
 
-## 에이전트 제어
+## Agent Control
 
-OpenCode 에이전트 전환은 Tab 기반으로 수행한다.
+OpenCode agent switching is Tab-based.
 
-| 에이전트 | 용도 | 전환 |
-|----------|------|------|
-| Sisyphus | 기본 구현/수정 | 기본 상태 |
-| Hephaestus | 깊은 구현/리팩토링 | Tab 1회 |
-| Prometheus | 계획 수립/전략화 | Tab 2회 |
+| Agent | Purpose | Switch |
+|-------|---------|--------|
+| Sisyphus | Default implementation/fixes | Default state |
+| Hephaestus | Deep implementation/refactoring | Tab x1 |
+| Prometheus | Planning/strategy | Tab x2 |
 
 ```bash
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Tab
@@ -63,109 +63,109 @@ sleep 1
 tmux -S "$SOCKET" capture-pane -p -J -t opencode:0.0 -S -20
 ```
 
-## 모델 선택 가이드
+## Model Selection Guide
 
-- 빠른 수정: 속도 우선 모델
-- 복잡한 리팩토링/설계: 심층 추론 모델
-- 계획 전용 단계: 최고 추론 모델 우선
+- Quick fixes: speed-priority model
+- Complex refactoring/design: deep reasoning model
+- Planning-only phase: highest reasoning model preferred
 
-실행 시점에 프로젝트 표준 라우팅(quick/deep/ultrabrain)을 따른다.
+Follow the project standard routing (quick/deep/ultrabrain) at execution time.
 
-## Plan -> Build 워크플로우
+## Plan → Build Workflow
 
-1) Prometheus로 계획 수립
-2) 계획 승인/정리
-3) Sisyphus 또는 Hephaestus로 구현 전환
-4) 테스트/빌드/검증 실행
-5) 결과를 OpenClaw가 수집해 최종 보고
+1) Create plan with Prometheus
+2) Approve/refine the plan
+3) Switch to Sisyphus or Hephaestus for implementation
+4) Run tests/build/verification
+5) OpenClaw collects results and delivers final report
 
 ```bash
-# Plan 단계
+# Plan phase
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Tab
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Tab
 sleep 0.2
-tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- '계획 수립: 인증 모듈 리팩토링 범위/리스크/검증전략 작성'
+tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'Plan: auth module refactoring scope/risk/verification strategy'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 
-# Build 단계 전환(예: Sisyphus로 복귀 후 구현)
+# Build phase (switch back to Sisyphus for implementation)
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Escape
-tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'ultrawork 위 계획 기준으로 구현 시작, 테스트까지 완료'
+tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'ultrawork implement based on the plan above, complete with tests'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 ```
 
-## OmO 위임 패턴
+## OmO Delegation Pattern
 
-### 1) tmux 세션 검증
+### 1) tmux Session Verification
 
 ```bash
 SOCKET="/tmp/openclaw-tmux-sockets/openclaw.sock"
 tmux -S "$SOCKET" has-session -t opencode
 ```
 
-### 2) 에이전트 선택표
+### 2) Agent Selection
 
-| 목적 | 에이전트 | 전환 |
-|------|----------|------|
-| 기본 실행 | Sisyphus | 기본 |
-| 깊은 구현 | Hephaestus | Tab 1회 |
-| 계획 수립 | Prometheus | Tab 2회 |
+| Purpose | Agent | Switch |
+|---------|-------|--------|
+| Default execution | Sisyphus | Default |
+| Deep implementation | Hephaestus | Tab x1 |
+| Planning | Prometheus | Tab x2 |
 
-### 3) 작업 전송 (`send-keys -l` + Enter 분리)
+### 3) Task Sending (`send-keys -l` + separate Enter)
 
 ```bash
-TASK='ultrawork 결제 실패 버그 수정. 재현, 원인 분석, 테스트 추가, 회귀 방지 포함.'
+TASK='ultrawork fix payment failure bug. Include reproduction, root cause analysis, test addition, regression prevention.'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- "$TASK"
 sleep 0.1
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 ```
 
-### 4) 작업 템플릿
+### 4) Task Templates
 
-기능 구현:
+Feature implementation:
 ```text
-ultrawork [기능] 구현.
-요구사항:
-- [요구 1]
-- [요구 2]
-기존 [참조 파일] 패턴을 따르고 테스트까지 수행.
+ultrawork implement [feature].
+Requirements:
+- [requirement 1]
+- [requirement 2]
+Follow existing [reference file] patterns and run tests.
 ```
 
-버그 수정:
+Bug fix:
 ```text
-ultrawork [버그 설명] 수정.
-재현 경로: [steps]
-에러: [message]
-기대 동작: [expected]
+ultrawork fix [bug description].
+Reproduction: [steps]
+Error: [message]
+Expected: [expected behavior]
 ```
 
-리팩토링:
+Refactoring:
 ```text
-ultrawork [모듈] 리팩토링.
-목표:
-- [목표 1]
-- [목표 2]
-제약:
-- Public API 변경 금지
-- 기존 테스트 통과
+ultrawork refactor [module].
+Goals:
+- [goal 1]
+- [goal 2]
+Constraints:
+- No public API changes
+- Existing tests must pass
 ```
 
-리서치 + 구현:
+Research + implementation:
 ```text
-[/path/to/research.md]를 먼저 읽고,
-ultrawork 연구 결과 기준으로 [기능] 구현.
+Read [/path/to/research.md] first,
+ultrawork implement [feature] based on research findings.
 ```
 
-### 5) 진행 모니터링 (`capture-pane`)
+### 5) Progress Monitoring (`capture-pane`)
 
 ```bash
 tmux -S "$SOCKET" capture-pane -p -J -t opencode:0.0 -S -200
 ```
 
-권장:
-- 10-30초 주기로 진행 로그 확인
-- 막힘 징후(동일 출력 반복, 프롬프트 대기) 즉시 개입
+Recommendations:
+- Check progress logs at 10-30 second intervals
+- Intervene immediately on stall signs (repeated output, prompt waiting)
 
-### 6) 결과 수집 (`git status`/`git diff`)
+### 6) Result Collection (`git status`/`git diff`)
 
 ```bash
 git status
@@ -173,25 +173,25 @@ git diff --stat
 git diff
 ```
 
-OpenClaw는 변경 파일/테스트 결과/리스크를 요약해 사용자에게 전달한다.
+OpenClaw summarizes changed files/test results/risks and delivers to the user.
 
-### 7) 에러 복구
+### 7) Error Recovery
 
 ```bash
-# 현재 동작 중단
+# Stop current operation
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Escape
 
-# 수정 지시 재전송
-tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- '직전 단계에서 테스트 실패 원인만 먼저 해결해.'
+# Resend corrected instruction
+tmux -S "$SOCKET" send-keys -t opencode:0.0 -l -- 'Resolve only the test failure from the previous step first.'
 tmux -S "$SOCKET" send-keys -t opencode:0.0 Enter
 
-# 세션 재시작
+# Session restart
 tmux -S "$SOCKET" kill-session -t opencode
 tmux -S "$SOCKET" new -d -s opencode -n main
 ```
 
-## 운영 체크리스트
+## Operations Checklist
 
-- 세션 alive 확인 -> 에이전트 선택 -> 작업 전송 -> 모니터링 -> 결과 수집
-- 항상 `send-keys -l` + 별도 Enter
-- 결과 보고 전에 `git status`/`git diff`로 변경 검증
+- Session alive check → agent selection → task send → monitoring → result collection
+- Always use `send-keys -l` + separate Enter
+- Verify changes with `git status`/`git diff` before reporting results

--- a/skills/steering-words.md
+++ b/skills/steering-words.md
@@ -5,55 +5,55 @@ description: Detect ultrawork/search/analyze family keywords in multilingual pro
 
 # Steering Words - Keyword Detection Skill
 
-키워드 기반으로 사용자 의도를 빠르게 분류하고 적절한 에이전트 모드를 추천한다.
+Quickly classify user intent based on keywords and recommend the appropriate agent mode.
 
-## 목적
+## Purpose
 
-- 입력 프롬프트에서 **steering words**를 감지
-- `ultrawork / search / analyze` 패밀리로 분류
-- 한국어/일본어/중국어 키워드를 포함해 모드 추천
+- Detect **steering words** in input prompts
+- Classify into `ultrawork / search / analyze` families
+- Recommend mode including multilingual keywords (Korean, Japanese, Chinese)
 
 ## Detection Families
 
 ### 1) Ultrawork Family
 
 - English: `ultrawork`, `ulw`, `full throttle`, `maximum effort`, `deep think`
-- 한국어: `울트라워크`, `풀가동`, `최대 노력`, `끝까지`, `전부 자동`
-- 日本語: `ウルトラワーク`, `全力`, `最大努力`, `最後まで`, `自動実行`
-- 中文: `超强模式`, `全力模式`, `最大努力`, `一路做完`, `全自动`
+- Korean: `울트라워크`, `풀가동`, `최대 노력`, `끝까지`, `전부 자동`
+- Japanese: `ウルトラワーク`, `全力`, `最大努力`, `最後まで`, `自動実行`
+- Chinese: `超强模式`, `全力模式`, `最大努力`, `一路做完`, `全自动`
 
-**추천 모드**
-- 우선: `/ultrawork`
-- 대안: 복잡 구현이면 `hephaestus`, 복잡 계획이면 `prometheus`
+**Recommended mode**
+- Primary: `/ultrawork`
+- Alternative: `hephaestus` for complex implementation, `prometheus` for complex planning
 
 ### 2) Search Family
 
 - English: `search`, `find`, `locate`, `lookup`, `scan`, `trace`, `where is`, `list all`
-- 한국어: `찾아`, `검색`, `어디`, `전부 보여`, `목록`
-- 日本語: `探して`, `検索`, `どこ`, `一覧`, `全部見せて`
-- 中文: `查找`, `搜索`, `哪里`, `列出`, `全部显示`
+- Korean: `���아`, `검색`, `어디`, `전부 보여`, `목록`
+- Japanese: `探して`, `検索`, `どこ`, `一覧`, `全部見せて`
+- Chinese: `查找`, `搜索`, `哪里`, `列出`, `全部显示`
 
-**추천 모드**
-- 우선: `explore` (코드베이스 탐색)
-- 외부 문서/OSS 필요 시: `librarian` 병행
+**Recommended mode**
+- Primary: `explore` (codebase search)
+- Supplement with `librarian` when external docs/OSS are needed
 
 ### 3) Analyze Family
 
 - English: `analyze`, `analyse`, `investigate`, `examine`, `research`, `audit`, `why`, `how does`
-- 한국어: `분석`, `조사`, `검토`, `원인`, `왜`, `어떻게`
-- 日本語: `分析`, `調査`, `検証`, `原因`, `なぜ`, `どうして`
-- 中文: `分析`, `调查`, `排查`, `原因`, `为什么`, `怎么`
+- Korean: `분석`, `조사`, `검토`, `원인`, `왜`, `어떻게`
+- Japanese: `分析`, `調査`, `検証`, `原因`, `なぜ`, `どうして`
+- Chinese: `分析`, `调查`, `排查`, `原因`, `为什么`, `怎么`
 
-**추천 모드**
-- 우선: `metis` (의도 분류/범위 정제)
-- 아키텍처 트레이드오프 포함 시: `oracle`
+**Recommended mode**
+- Primary: `metis` (intent classification / scope refinement)
+- Include `oracle` when architecture tradeoffs are involved
 
 ## Scoring Rule
 
-1. 패밀리별 키워드 매칭 수를 집계
-2. 최다 점수 패밀리를 선택
-3. 동점이면 우선순위: `ultrawork > analyze > search`
-4. 모호하면 `metis` 추천 후 재분류
+1. Count keyword matches per family
+2. Select the highest-scoring family
+3. On tie, priority order: `ultrawork > analyze > search`
+4. If ambiguous, recommend `metis` for re-classification
 
 ## Output Template
 
@@ -67,6 +67,6 @@ description: Detect ultrawork/search/analyze family keywords in multilingual pro
 
 ## Guardrails
 
-- 키워드 감지는 힌트이며 절대 규칙이 아니다.
-- 명시적 사용자 지시가 있으면 키워드보다 우선한다.
-- 다국어 혼합 입력은 단일 언어로 정규화하지 말고 그대로 매칭한다.
+- Keyword detection is a hint, not an absolute rule.
+- Explicit user instructions take precedence over keywords.
+- Do not normalize multilingual mixed input into a single language — match as-is.

--- a/skills/tmux-agents.md
+++ b/skills/tmux-agents.md
@@ -1,103 +1,103 @@
 ---
 name: tmux-agents
-description: tmux 세션에서 코딩 에이전트(Claude Code, Codex, Gemini, Ollama)를 스폰하고 모니터링한다.
+description: Spawn and monitor coding agents (Claude Code, Codex, Gemini, Ollama) in tmux sessions.
 ---
 
-# tmux-agents — 에이전트 스폰/모니터링 가이드
+# tmux-agents — Agent Spawn/Monitoring Guide
 
-tmux 안에서 코딩 에이전트를 띄우고, 상태를 확인하고, 병렬로 운영하는 실행 패턴 모음.
+Patterns for spawning coding agents in tmux, checking status, and running parallel operations.
 
-## 에이전트 종류
+## Agent Types
 
-| 구분 | 에이전트 ID | 실행 위치 | 특성 |
-|------|-------------|----------|------|
-| cloud | `claude` | 원격 API | 고품질 추론, 안정적 |
-| cloud | `codex` | 원격 API | 코드 생성/수정 강점 |
-| cloud | `gemini` | 원격 API | 멀티모달/긴 문맥 강점 |
-| local | `ollama-claude` | 로컬 Ollama | 비용 절감, 오프라인 가능 |
-| local | `ollama-codex` | 로컬 Ollama | 로컬 코드 작업 최적화 |
+| Type | Agent ID | Runtime | Characteristics |
+|------|----------|---------|-----------------|
+| cloud | `claude` | Remote API | High-quality reasoning, stable |
+| cloud | `codex` | Remote API | Strong code generation/modification |
+| cloud | `gemini` | Remote API | Strong multimodal/long context |
+| local | `ollama-claude` | Local Ollama | Cost reduction, offline capable |
+| local | `ollama-codex` | Local Ollama | Optimized for local code tasks |
 
-## 빠른 명령 모음
+## Quick Commands
 
-아래 명령은 tmux-agents 헬퍼 스크립트 인터페이스를 기준으로 한다.
+Commands below follow the tmux-agents helper script interface.
 
 ```bash
-# 1) 스폰
+# 1) Spawn
 ./spawn.sh --agent codex --session opencode-2 --cwd /path/to/project
 
-# 2) 목록
+# 2) List
 ./status.sh list
 
-# 3) 헬스체크
+# 3) Health check
 ./check.sh --session opencode-2
 
-# 4) 붙기
+# 4) Attach
 tmux attach -t opencode-2
 
-# 5) 지시 전송 (안전 입력)
+# 5) Send instruction (safe input)
 tmux send-keys -t opencode-2:0.0 -l -- 'Fix failing tests in auth module'
 tmux send-keys -t opencode-2:0.0 Enter
 
-# 6) 종료
+# 6) Kill
 tmux kill-session -t opencode-2
 ```
 
-## 병렬 에이전트 패턴
+## Parallel Agent Pattern
 
 ```bash
-# 병렬 스폰 예시
+# Parallel spawn example
 ./spawn.sh --agent codex --session opencode --cwd /repo/a
 ./spawn.sh --agent claude --session opencode-2 --cwd /repo/b
 ./spawn.sh --agent gemini --session gemini --cwd /repo/a
 
-# 병렬 진행 후 상태 점검
+# Status check after parallel progress
 ./status.sh list
 ./check.sh --session opencode
 ./check.sh --session opencode-2
 ./check.sh --session gemini
 ```
 
-운영 원칙:
-- 구현 세션과 검증 세션을 분리
-- 긴 작업은 10-30초 간격으로 주기 점검
-- 완료 후 세션별 결과를 순차 수집
+Operational principles:
+- Separate implementation sessions from verification sessions
+- Check long tasks at 10-30 second intervals
+- Collect results sequentially after completion
 
-## Local vs Cloud 선택 기준
+## Local vs Cloud Selection
 
-| 상황 | 권장 | 이유 |
-|------|------|------|
-| 속도보다 품질이 중요 | cloud | 최신 모델 품질/추론 강점 |
-| 장시간 반복 작업 | local | 비용 절감, 호출 제한 없음 |
-| 외부 네트워크 제약 | local | 오프라인/폐쇄망 대응 |
-| 멀티모달 분석 필요 | cloud(gemini) | 이미지/PDF 처리 품질 |
-| 민감 코드 로컬 처리 | local | 데이터 외부 전송 최소화 |
+| Situation | Recommended | Reason |
+|-----------|-------------|--------|
+| Quality over speed | cloud | Latest model quality/reasoning strength |
+| Long repeated tasks | local | Cost reduction, no rate limits |
+| Network restrictions | local | Offline/air-gapped compatibility |
+| Multimodal analysis needed | cloud (gemini) | Image/PDF processing quality |
+| Sensitive code processing | local | Minimize data exfiltration |
 
-## Ollama 준비
+## Ollama Setup
 
 ```bash
-# Ollama 실행 확인
+# Check Ollama status
 ollama list
 
-# 필요한 모델 다운로드(예시)
+# Download required models (example)
 ollama pull qwen2.5-coder:14b
 ollama pull llama3.1:8b
 
-# 로컬 응답 확인
+# Verify local response
 curl http://127.0.0.1:11434/api/tags
 ```
 
-권장:
-- 코딩용 모델 + 범용 대화 모델 1개씩 준비
-- RAM/VRAM 한계를 고려해 동시 실행 수 제한
+Recommendations:
+- Prepare one coding model + one general conversation model
+- Limit concurrent executions considering RAM/VRAM limits
 
-## 팁
+## Tips
 
-- 세션 타겟은 항상 `session:window.pane`으로 고정 (`opencode-2:0.0`)
-- 텍스트 입력은 `send-keys -l` 후 Enter 분리
-- 출력 확인은 `capture-pane -p -J -S -200` 기본 사용
-- 실패 세션은 즉시 재생성하고 동일 프롬프트 재투입
+- Always specify session targets as `session:window.pane` (`opencode-2:0.0`)
+- Text input: `send-keys -l` followed by separate Enter
+- Output check: use `capture-pane -p -J -S -200` as default
+- Failed sessions: immediately recreate and re-send the same prompt
 
-## 헬퍼 스크립트 범위
+## Helper Script Scope
 
-`spawn.sh`, `status.sh`, `check.sh`는 공식 `openclaw/skills/tmux-agents` 패키지에서 제공되는 헬퍼 스크립트 인터페이스를 따른다.
-이 문서는 스크립트 사용법 자체가 아니라, OpenClaw/OmO 운영 관점의 실행 지식을 제공한다.
+`spawn.sh`, `status.sh`, `check.sh` follow the helper script interface provided by the official `openclaw/skills/tmux-agents` package.
+This document provides operational knowledge from the OpenClaw/OmO perspective, not script usage itself.

--- a/skills/web-search.md
+++ b/skills/web-search.md
@@ -1,133 +1,133 @@
 ---
 name: web-search
-description: 웹 검색 및 정보 수집 스킬. OmO의 websearch/context7/grep_app MCP 패턴을 OpenClaw 네이티브 도구 + mcporter MCP로 통합. 웹 검색, 페이지 읽기, 라이브러리 문서 검색, 오픈소스 코드 검색을 지원한다.
+description: Web search and information gathering skill. Integrates OmO's websearch/context7/grep_app MCP patterns into OpenClaw native tools + mcporter MCP. Supports web search, page reading, library docs search, and open-source code search.
 ---
 
 # Web Search Skill
 
-웹에서 정보를 수집하는 통합 스킬. OpenClaw 네이티브 도구(`web_fetch`)와 mcporter MCP 서버를 조합하여 다양한 검색 전략을 제공한다.
+Unified skill for gathering information from the web. Combines OpenClaw native tools (`web_fetch`) with mcporter MCP servers to provide diverse search strategies.
 
-## 도구 우선순위
+## Tool Priority
 
-상황에 따라 최적의 도구를 선택:
+Select the optimal tool based on the situation:
 
-### 1. OpenClaw 네이티브 `web_fetch` (기본)
-가장 빠르고 간단. URL을 알고 있거나 간단한 페이지 읽기에 적합.
+### 1. OpenClaw Native `web_fetch` (default)
+Fastest and simplest. Best when you have the URL or need simple page reading.
 ```
 web_fetch(url="https://example.com", extractMode="markdown")
 ```
-- 별도 설정 불필요
-- HTML → markdown/text 자동 변환
-- `maxChars`로 응답 크기 제한 가능
+- No additional setup needed
+- Auto-converts HTML → markdown/text
+- Response size limitable via `maxChars`
 
-### 2. mcporter `web-search-prime` (웹 검색)
-키워드 기반 웹 검색. 최신 정보, 뉴스, 기술 블로그 검색에 적합.
+### 2. mcporter `web-search-prime` (web search)
+Keyword-based web search. Best for latest info, news, tech blogs.
 ```bash
 mcporter call web-search-prime.webSearchPrime \
-  search_query="검색어" \
+  search_query="search terms" \
   location="us" \
   content_size="medium"
 ```
-**파라미터:**
-- `search_query` (필수): 검색 키워드
-- `location`: `us` | `kr` | `jp` 등 (기본: `us`)
-- `content_size`: `medium` (기본) | `high` (상세, ~2500자)
+**Parameters:**
+- `search_query` (required): Search keywords
+- `location`: `us` | `kr` | `jp` etc. (default: `us`)
+- `content_size`: `medium` (default) | `high` (detailed, ~2500 chars)
 - `search_recency_filter`: `oneDay` | `oneWeek` | `oneMonth` | `oneYear` | `noLimit`
 
-### 3. mcporter `web-reader` (페이지 전문 읽기)
-특정 URL의 전체 내용을 깔끔하게 추출. `web_fetch`보다 정확한 추출이 필요할 때.
+### 3. mcporter `web-reader` (full page reading)
+Clean extraction of full page content. Use when `web_fetch` extraction is incomplete.
 ```bash
 mcporter call web-reader.webReader \
   url="https://example.com" \
   return_format="markdown"
 ```
-**파라미터:**
-- `url` (필수): 읽을 URL
-- `return_format`: `markdown` (기본) | `text`
-- `retain_images`: `true` (기본) | `false`
-- `with_links_summary`: `true` | `false` (문서 내 링크 요약)
+**Parameters:**
+- `url` (required): URL to read
+- `return_format`: `markdown` (default) | `text`
+- `retain_images`: `true` (default) | `false`
+- `with_links_summary`: `true` | `false` (summarize links in doc)
 
-### 4. mcporter `exa` (시맨틱 웹 검색)
-OmO의 기본 웹서치. 의미 기반(semantic) 검색으로 키워드보다 정확한 결과.
+### 4. mcporter `exa` (semantic web search)
+OmO's default web search. Semantic search for more accurate results than keywords.
 ```bash
 mcporter call exa.web_search_exa \
-  query="검색어"
+  query="search terms"
 ```
-- API 키 없이도 동작 (기본 제공)
-- 시맨틱 검색 지원 (질문 형태로 검색하면 더 좋은 결과)
+- Works without API key (provided by default)
+- Semantic search (question-form queries yield better results)
 
-### 5. mcporter `context7` (라이브러리 문서 검색)
-프로그래밍 라이브러리/프레임워크의 공식 문서를 검색.
+### 5. mcporter `context7` (library docs search)
+Search official docs for programming libraries/frameworks.
 ```bash
-# 라이브러리 검색
+# Find library
 mcporter call context7.resolve-library-id \
   libraryName="react"
 
-# 문서 검색
+# Search docs
 mcporter call context7.query-docs \
   libraryId="/facebook/react" \
   query="hooks"
 ```
-**용도:**
-- 라이브러리 API 레퍼런스 확인
-- 프레임워크 사용법 검색
-- 최신 버전 변경사항 확인
+**Use for:**
+- Library API reference lookup
+- Framework usage search
+- Latest version changelog
 
-### 6. mcporter `grep_app` (오픈소스 코드 검색)
-GitHub 등 오픈소스 코드에서 패턴/사용 예시를 검색.
+### 6. mcporter `grep_app` (open-source code search)
+Search patterns/usage examples in GitHub and other open-source code.
 ```bash
 mcporter call grep_app.search \
   query="useEffect cleanup" \
   language="typescript"
 ```
-**용도:**
-- 실제 프로젝트에서의 API 사용 예시 찾기
-- 특정 패턴/에러의 해결책 검색
-- 라이브러리 통합 방법 확인
+**Use for:**
+- Finding real-world API usage examples
+- Searching for pattern/error solutions
+- Library integration examples
 
-### 7. mcporter `zread` (GitHub 리포 직접 탐색)
-특정 GitHub 리포지토리의 파일/문서를 직접 읽기.
+### 7. mcporter `zread` (GitHub repo direct access)
+Directly read files/docs from specific GitHub repositories.
 ```bash
-# 리포 구조 확인
+# Check repo structure
 mcporter call zread.get_repo_structure \
   repo_name="owner/repo"
 
-# 파일 읽기
+# Read file
 mcporter call zread.read_file \
   repo_name="owner/repo" \
   file_path="src/index.ts"
 
-# 문서/이슈 검색
+# Search docs/issues
 mcporter call zread.search_doc \
   repo_name="owner/repo" \
-  query="검색어"
+  query="search terms"
 ```
 
-## 검색 전략 가이드
+## Search Strategy Guide
 
-### 일반 검색 (뉴스, 블로그, 일반 정보)
-1. `web-search-prime` → 검색 결과 → `web_fetch`로 상세 페이지 읽기
+### General Search (news, blogs, general info)
+1. `web-search-prime` → results → `web_fetch` for detailed page reading
 
-### 기술 문서 검색
-1. `context7`로 라이브러리 문서 직접 검색
-2. 없으면 `web-search-prime`으로 공식 문서 URL 찾기 → `web_fetch`
+### Technical Documentation
+1. `context7` for direct library docs search
+2. If not found, `web-search-prime` to find official docs URL → `web_fetch`
 
-### 코드 예시 검색
-1. `grep_app`으로 오픈소스 코드에서 패턴 검색
-2. `zread`로 특정 리포 파일 직접 읽기
-3. `context7`로 라이브러리 공식 예시 확인
+### Code Examples
+1. `grep_app` for pattern search in open-source code
+2. `zread` for direct file reading from specific repos
+3. `context7` for official library examples
 
-### 특정 사이트 정보
-1. `web_fetch`로 직접 URL 읽기 (가장 빠름)
-2. 내용 추출이 불완전하면 `web-reader`로 재시도
+### Specific Site Info
+1. `web_fetch` for direct URL reading (fastest)
+2. If extraction is incomplete, retry with `web-reader`
 
-### 최신 정보 (오늘/이번 주)
-1. `web-search-prime` + `search_recency_filter="oneDay"` 또는 `"oneWeek"`
-2. `exa`로 시맨틱 검색 보완
+### Latest Info (today/this week)
+1. `web-search-prime` + `search_recency_filter="oneDay"` or `"oneWeek"`
+2. Supplement with `exa` semantic search
 
-## mcporter 설정
+## mcporter Configuration
 
-MCP 서버들은 `~/.openclaw/workspace/config/mcporter.json`에 설정되어 있다:
+MCP servers are configured in `~/.openclaw/workspace/config/mcporter.json`:
 
 ```json
 {
@@ -142,14 +142,14 @@ MCP 서버들은 `~/.openclaw/workspace/config/mcporter.json`에 설정되어 �
 }
 ```
 
-## OmO 대응표
+## OmO Mapping Table
 
-| OmO (MCP)       | oh-my-openclaw 대응                              |
-|------------------|--------------------------------------------------|
-| `websearch` (Exa)| `mcporter call exa.web_search_exa` + `web_fetch` |
-| `websearch` (Tavily)| `mcporter call web-search-prime.webSearchPrime`|
-| `context7`       | `mcporter call context7.resolve-library-id` / `.query-docs` |
-| `grep_app`       | `mcporter call grep_app.search`                  |
-| *(없음)*         | `web_fetch` (OpenClaw 네이티브)                   |
-| *(없음)*         | `web-reader` (MCP, 깔끔한 페이지 추출)            |
-| *(없음)*         | `zread` (MCP, GitHub 리포 직접 탐색)               |
+| OmO (MCP) | oh-my-openclaw equivalent |
+|-----------|---------------------------|
+| `websearch` (Exa) | `mcporter call exa.web_search_exa` + `web_fetch` |
+| `websearch` (Tavily) | `mcporter call web-search-prime.webSearchPrime` |
+| `context7` | `mcporter call context7.resolve-library-id` / `.query-docs` |
+| `grep_app` | `mcporter call grep_app.search` |
+| *(none)* | `web_fetch` (OpenClaw native) |
+| *(none)* | `web-reader` (MCP, clean page extraction) |
+| *(none)* | `zread` (MCP, direct GitHub repo access) |

--- a/skills/workflow-auto-rescue.md
+++ b/skills/workflow-auto-rescue.md
@@ -5,26 +5,26 @@ description: Session recovery workflow with checkpointing, failure detection, an
 
 # Auto-Rescue Workflow
 
-장시간 작업 중 실패/중단 상황에서 세션을 자동 복구한다.
+Automatically recover sessions after failure/interruption during long-running tasks.
 
 ## When to Use
 
-- 긴 구현/리팩터링 세션
-- 다중 단계 작업(5+ step)
-- 반복 실패 가능성이 높은 디버깅/빌드 복구 작업
+- Long implementation/refactoring sessions
+- Multi-step tasks (5+ steps)
+- Debugging/build recovery tasks with high failure probability
 
 ## Core Mechanism
 
-- **Checkpoint 저장**: 주요 단계마다 `write` 도구로 파일 저장 (`workspace/checkpoints/`)
-- **Checkpoint 조회**: 복구 시 `read` 도구 + `memory_search` (OpenClaw 네이티브)
-- **자동 복원**: 가장 최근 정상 상태부터 재시작
+- **Checkpoint save**: Save file via `write` tool at major steps (`workspace/checkpoints/`)
+- **Checkpoint lookup**: Use `read` tool + `memory_search` (OpenClaw native) for recovery
+- **Auto-restore**: Restart from the most recent healthy state
 
-> **Note**: OpenClaw의 `group:memory`에는 `memory_search`/`memory_get`만 존재하고
-> `memory_store`는 없다. 저장은 반드시 파일 기반(`write`)으로 수행한다.
+> **Note**: OpenClaw's `group:memory` only has `memory_search`/`memory_get`.
+> `memory_store` does not exist. Storage must be file-based (`write`).
 
 ## Checkpoint Schema
 
-`workspace/checkpoints/checkpoint-<timestamp>.json`에 다음 형태로 저장한다:
+Save to `workspace/checkpoints/checkpoint-<timestamp>.json` in this format:
 
 ```json
 {
@@ -47,56 +47,56 @@ description: Session recovery workflow with checkpointing, failure detection, an
 
 ### 1) Start Monitoring
 
-1. 세션 시작 시 checkpoint baseline 저장 (`write` → `workspace/checkpoints/`)
-2. todo 기준으로 단계 전환마다 checkpoint 갱신
-3. 실패 가능 작업 전(대규모 edit/build/test) 선저장
+1. Save checkpoint baseline at session start (`write` → `workspace/checkpoints/`)
+2. Update checkpoint at every step transition (based on todos)
+3. Pre-save before potentially failing tasks (large edit/build/test)
 
 ### 2) Failure Detection
 
-다음 중 하나면 rescue 트리거:
+Trigger rescue if any of these occur:
 
-- 동일 오류 3회 연속 발생
-- 빌드/테스트가 연속 실패하고 진행 불가
-- 세션 중단(타임아웃/강제 인터럽트/에이전트 중지)
+- Same error 3 consecutive times
+- Build/test continuously failing with no progress possible
+- Session interruption (timeout/forced interrupt/agent stop)
 
 ### 3) Recovery Procedure
 
-1. `read` 도구로 `workspace/checkpoints/` 내 최근 checkpoint 파일 읽기
-2. 가장 최신 `verification`이 정상(pass)인 지점 선택
-3. 해당 시점의 `next_action`부터 재개
-4. 동일 실패 재발 시 한 단계 이전 checkpoint로 롤백
+1. Read the most recent checkpoint file from `workspace/checkpoints/` via `read` tool
+2. Select the latest checkpoint where `verification` is passing
+3. Resume from that checkpoint's `next_action`
+4. If same failure recurs, roll back to one checkpoint earlier
 
 ### 4) Post-Recovery
 
-1. 복구 성공 상태를 새 checkpoint 파일로 저장 (`write`)
-2. 실패 원인/해결을 `workspace/notepads/issues.md`에 기록
-3. 남은 단계 계속 진행
+1. Save recovery success state as a new checkpoint file (`write`)
+2. Record failure cause/resolution in `workspace/notepads/issues.md`
+3. Continue with remaining steps
 
 ## OpenClaw Tool Mapping
 
-| 동작            | 사용할 도구     | 비고                                         |
-| --------------- | --------------- | -------------------------------------------- |
-| Checkpoint 저장 | `write`         | `workspace/checkpoints/checkpoint-<ts>.json` |
-| Checkpoint 읽기 | `read`          | 직접 파일 경로 지정                          |
-| 과거 기억 검색  | `memory_search` | OpenClaw `group:memory`                      |
-| 특정 기억 조회  | `memory_get`    | key 기반                                     |
-| 파일 목록 확인  | `exec` (ls)     | checkpoint 디렉토리 스캔                     |
+| Action | Tool | Notes |
+|--------|------|-------|
+| Checkpoint save | `write` | `workspace/checkpoints/checkpoint-<ts>.json` |
+| Checkpoint read | `read` | Direct file path |
+| Search past context | `memory_search` | OpenClaw `group:memory` |
+| Get specific memory | `memory_get` | key-based |
+| List files | `exec` (ls) | Scan checkpoint directory |
 
 ## Example
 
 ```text
-# 저장
+# Save
 write({ path: "workspace/checkpoints/checkpoint-2026-02-22T13-00.json", content: "{ ... }" })
 
-# 복구 시 읽기
+# Read on recovery
 read({ path: "workspace/checkpoints/checkpoint-2026-02-22T13-00.json" })
 
-# 세션 기억에서 관련 컨텍스트 검색
+# Search session memory for related context
 memory_search({ query: "session-checkpoint auth refactor" })
 ```
 
 ## Completion Criteria
 
-- 복구 후 작업이 실제로 재개됨
-- 최신 checkpoint 파일이 저장됨
-- 동일 실패 루프가 차단됨
+- Work actually resumes after recovery
+- Latest checkpoint file is saved
+- Same-failure loops are blocked

--- a/skills/workflow-tool-patterns.md
+++ b/skills/workflow-tool-patterns.md
@@ -1,85 +1,85 @@
 ---
 name: workflow-tool-patterns
-description: OmO src/tools 패턴을 OpenClaw에서 재사용 가능한 실행 패턴으로 매핑하는 워크플로우
+description: Maps OmO src/tools patterns into reusable execution patterns for OpenClaw
 ---
 
 # Tool Patterns Workflow (OmO → OpenClaw)
 
-OmO의 `src/tools/` 구조를 기준으로, OpenClaw에서 실사용 가능한 도구 패턴을 표준화한다.
+Standardizes tool usage patterns in OpenClaw based on OmO's `src/tools/` structure.
 
-## 목적
+## Purpose
 
-- 도구 선택 실수를 줄이고
-- 반복 가능한 실행 루틴을 만들며
-- 계획/실행/검증 단계를 일관되게 유지한다.
+- Reduce tool selection mistakes
+- Create repeatable execution routines
+- Maintain consistency across planning/execution/verification phases
 
-## 패턴 매핑
+## Pattern Mapping
 
-> **중요**: 아래 테이블의 "OpenClaw 도구"는 모두 OpenClaw 공식 도구 인벤토리에 실제 존재하는 도구들이다.
+> **Important**: All "OpenClaw tools" in the table below are actual tools in the OpenClaw official tool inventory.
 
-| OmO Tool Pattern          | 의도                 | OpenClaw 도구 & 사용 패턴                                          |
-| ------------------------- | -------------------- | ------------------------------------------------------------------ |
-| `task/*` (todo-sync)      | 작업 상태 추적       | 파일 기반 할 일 관리: `write`로 `workspace/todos.md` 갱신          |
-| `lsp/*` (goto/references) | 코드 탐색/검증       | `exec` 도구로 린터/타입체커 실행 → 결과로 검증                     |
-| `interactive-bash`        | 장시간/상호작용 셸   | `exec`(`pty: true`) 또는 tmux 연동                                 |
-| `bash`                    | 원샷 명령            | `exec`(동기), `exec`(`background: true`) → `process`(`poll`)       |
-| `slashcommand`            | 명령 워크플로우 구동 | OpenClaw 스킬 `/ultrawork`, `/plan`, `/start_work` (슬래시 커맨드) |
-| `session-manager`         | 세션 탐색/재개       | `sessions_list`, `sessions_history`, `session_status`              |
-| `skill-mcp`               | 스킬 기반 도구 호출  | OpenClaw 스킬 시스템 (`read` → SKILL.md 참조)                      |
-| `look-at`                 | 멀티모달 분석        | `image` 도구 + Gemini CLI tmux 연동                                |
-| `background-task`         | 병렬 작업            | `exec`(`background: true`) → `process`(`poll`/`log`/`kill`)        |
-| `file-read/write/edit`    | 파일 조작            | `read`, `write`, `edit`, `apply_patch` (`group:fs`)                |
-| `web-search`              | 웹 검색              | `web_search`, `web_fetch` (`group:web`)                            |
-| `memory`                  | 지식 축적            | `memory_search`, `memory_get` (`group:memory`)                     |
-| `delegation`              | 서브에이전트 위임    | `sessions_spawn`(`task`, `agentId`, `model`)                       |
+| OmO Tool Pattern | Intent | OpenClaw Tool & Usage Pattern |
+|------------------|--------|-------------------------------|
+| `task/*` (todo-sync) | Task state tracking | File-based todo management: `write` to update `workspace/todos.md` |
+| `lsp/*` (goto/references) | Code exploration/verification | `exec` tool to run linters/typecheckers → verify with results |
+| `interactive-bash` | Long-running/interactive shell | `exec`(`pty: true`) or tmux integration |
+| `bash` | One-shot command | `exec`(sync), `exec`(`background: true`) → `process`(`poll`) |
+| `slashcommand` | Trigger command workflows | OpenClaw skills `/ultrawork`, `/plan`, `/start_work` (slash commands) |
+| `session-manager` | Session browse/resume | `sessions_list`, `sessions_history`, `session_status` |
+| `skill-mcp` | Skill-based tool calls | OpenClaw skill system (`read` → SKILL.md reference) |
+| `look-at` | Multimodal analysis | `image` tool + Gemini CLI tmux integration |
+| `background-task` | Parallel tasks | `exec`(`background: true`) → `process`(`poll`/`log`/`kill`) |
+| `file-read/write/edit` | File manipulation | `read`, `write`, `edit`, `apply_patch` (`group:fs`) |
+| `web-search` | Web search | `web_search`, `web_fetch` (`group:web`) |
+| `memory` | Knowledge accumulation | `memory_search`, `memory_get` (`group:memory`) |
+| `delegation` | Sub-agent delegation | `sessions_spawn`(`task`, `agentId`, `model`) |
 
-## OpenClaw Tool Groups 정리
+## OpenClaw Tool Groups
 
-| Group            | 포함 도구                                        | 활용                         |
-| ---------------- | ------------------------------------------------ | ---------------------------- |
-| `group:fs`       | read, write, edit, apply_patch                   | 파일 조작 전반               |
-| `group:runtime`  | exec, bash, process                              | 명령 실행 + 백그라운드 관리  |
-| `group:sessions` | sessions_list/history/send/spawn, session_status | 멀티 에이전트                |
-| `group:memory`   | memory_search, memory_get                        | 지식 검색 (저장은 파일 기반) |
-| `group:web`      | web_search, web_fetch                            | 웹 검색/페치                 |
-| `group:ui`       | browser, canvas                                  | 브라우저/UI                  |
+| Group | Included Tools | Usage |
+|-------|---------------|-------|
+| `group:fs` | read, write, edit, apply_patch | All file manipulation |
+| `group:runtime` | exec, bash, process | Command execution + background management |
+| `group:sessions` | sessions_list/history/send/spawn, session_status | Multi-agent |
+| `group:memory` | memory_search, memory_get | Knowledge search (storage is file-based) |
+| `group:web` | web_search, web_fetch | Web search/fetch |
+| `group:ui` | browser, canvas | Browser/UI |
 
-## 실행 절차
+## Execution Procedure
 
-### 1) 계획 단계
+### 1) Planning Phase
 
-1. 복잡 작업이면 `write`로 `workspace/todos.md` 생성
-2. 탐색은 `exec` + grep/find 우선
-3. 외부 의존성은 `web_search`/`web_fetch` 또는 librarian 에이전트 병행
+1. For complex tasks, create `workspace/todos.md` with `write`
+2. Use `exec` + grep/find for exploration
+3. For external dependencies, use `web_search`/`web_fetch` or librarian agent in parallel
 
-### 2) 구현 단계
+### 2) Implementation Phase
 
-1. 변경 전 `read` + `exec`(grep)로 영향도 파악
-2. 작은 단위로 `edit`/`apply_patch` 수정
-3. 필요 시 `sessions_spawn`로 전문 에이전트 위임
+1. Use `read` + `exec`(grep) to assess impact before changes
+2. Make small-unit `edit`/`apply_patch` modifications
+3. Delegate to specialized agents via `sessions_spawn` when needed
 
-### 3) 검증 단계
+### 3) Verification Phase
 
-1. `exec`로 린터/타입체커 실행
-2. `exec`로 관련 테스트/빌드 실행
-3. 실패 시 원인-기반 `edit` 후 재검증
+1. Run linters/typecheckers with `exec`
+2. Run relevant tests/builds with `exec`
+3. On failure, apply cause-based `edit` and re-verify
 
-### 4) 병렬 작업 관리
+### 4) Parallel Task Management
 
-1. 독립 탐색/리서치는 `exec`(`background: true`)로 병렬 실행
-2. `process`(`poll`/`log`)로 결과 수집
-3. 최종 응답 전 `process`(`kill`)로 정리
+1. Run independent exploration/research with `exec`(`background: true`)
+2. Collect results with `process`(`poll`/`log`)
+3. Clean up with `process`(`kill`) before final response
 
-## 금지/주의 사항
+## Prohibited / Caution
 
-- 구현 미요청 상태에서 코드 변경 금지
-- 검증 없는 완료 보고 금지
-- 장시간 TUI 작업은 `exec`(`pty: true`) 사용
-- 수동 추정으로 API/패턴 확정하지 않기 (검색/근거 필수)
+- Do not change code when implementation was not requested
+- Do not report completion without verification
+- Use `exec`(`pty: true`) for long-running TUI tasks
+- Do not confirm APIs/patterns by guessing — search/evidence required
 
-## 체크리스트
+## Checklist
 
-- [ ] Todo 상태가 `workspace/todos.md`에 실시간 반영되었는가
-- [ ] 사용한 도구가 OpenClaw 공식 도구 인벤토리에 존재하는가
-- [ ] 변경 후 `exec`로 test/build 근거가 있는가
-- [ ] 백그라운드 작업이 `process`(`kill`)로 정리되었는가
+- [ ] Todo state reflected in real-time in `workspace/todos.md`
+- [ ] All tools used exist in OpenClaw's official tool inventory
+- [ ] Evidence from `exec` test/build after changes
+- [ ] Background tasks cleaned up with `process`(`kill`)

--- a/workflows/start-work.md
+++ b/workflows/start-work.md
@@ -51,8 +51,8 @@ Execute an approved plan by delegating tasks to appropriate worker agents, track
    c. **Delegate the task** via `sessions_spawn`:
    ```
    sessions_spawn(
-     task="7요소 프롬프트 (TASK/OUTCOME/SKILLS/TOOLS/MUST DO/MUST NOT/CONTEXT)",
-     agentId="omoc_sisyphus",  # 또는 적합한 전문 에이전트
+     task="7-element prompt (TASK/OUTCOME/SKILLS/TOOLS/MUST DO/MUST NOT/CONTEXT)",
+     agentId="omoc_sisyphus",  # or appropriate specialized agent
      model="...",
      label="task-N-name"
    )
@@ -63,10 +63,10 @@ Execute an approved plan by delegating tasks to appropriate worker agents, track
    - For implementation-heavy tasks, route to OmO via tmux orchestration stack
    - Require execution evidence (changed files, test/build outputs) before marking done
 
-   d. **서브에이전트 완료 통지 → 즉시 행동** (강제)
-   - 완료 통지를 받으면 결과를 즉시 확인한다
-   - Acceptance criteria와 대조 검증한다
-   - 멈추지 않는다 — 다음 task로 즉시 진행한다
+   d. **Sub-agent completion notification → immediate action** (mandatory)
+   - Check results immediately upon receiving completion notification
+   - Verify against acceptance criteria
+   - Do not stop — proceed to next task immediately
 
    e. **Mark task as completed** in todo list
 
@@ -74,9 +74,9 @@ Execute an approved plan by delegating tasks to appropriate worker agents, track
 
 4. **Handle parallel tasks**
    - Tasks with no mutual dependencies can run in parallel
-   - Use multiple `sessions_spawn` simultaneously (각각 다른 `label`로 식별)
-   - 각 완료 통지마다 해당 결과를 즉시 수집/검증
-   - 모든 병렬 task 완료 후 의존 task 즉시 시작
+   - Use multiple `sessions_spawn` simultaneously (each with different `label`)
+   - Collect and verify results immediately from each completion notification
+   - Start dependent tasks immediately after all parallel tasks complete
 
 ### Phase 3: Error Handling
 

--- a/workflows/ultrawork.md
+++ b/workflows/ultrawork.md
@@ -36,21 +36,21 @@ When the user invokes `/ultrawork [task description]` or ultrawork mode is activ
    a. Mark step as in_progress in todo list
    b. Delegate coding execution to worker sessions:
       - sessions_spawn(task=..., agentId="omoc_sisyphus", model=..., label=...)
-      - 전문 에이전트가 필요하면 agentId로 지정 (omoc_oracle, omoc_explore 등)
-   c. 서브에이전트 완료 통지를 받으면 즉시:
-      - 결과를 확인한다 (멈추지 않는다!)
-      - 성공 기준과 대조 검증한다
-      - 검증 통과 → 즉시 다음 step 진행
-      - 검증 실패 → 재시도 (최대 3회)
+      - Use agentId for specialized agents when needed (omoc_oracle, omoc_explore, etc.)
+   c. On sub-agent completion notification, immediately:
+      - Check results (do NOT stop!)
+      - Verify against success criteria
+      - On pass → proceed to next step immediately
+      - On fail → retry (max 3 times)
    d. Record any learnings in wisdom notepad
    e. Mark step as completed
    f. If step fails after 3 retries:
       - Record issue and continue with next independent step
 
-⚠️ CONTINUATION RULE (강제):
-- 서브에이전트 완료 통지 = 행동 트리거. 절대 멈추지 않는다.
-- 모든 step이 완료될 때까지 자동으로 다음 step을 진행한다.
-- 사용자 확인이 필요한 경우는 plan에 명시된 경우만 해당한다.
+⚠️ CONTINUATION RULE (mandatory):
+- Sub-agent completion notification = action trigger. Never stop.
+- Automatically proceed to next step until all steps are complete.
+- User confirmation is only needed when explicitly specified in the plan.
 ```
 
 ### Phase 3: Verification


### PR DESCRIPTION
## Summary

Major prompt-level redesign for token efficiency, internationalization, and OmO pattern adoption. **32 files changed** — no plugin source code (`dist/`/`bin/`) modifications.

## 🎯 Token Efficiency Delegation (Primary Change)

The main session runs the most expensive model (Claude Opus Thinking). This PR introduces a new delegation principle:

> **Any task that would inject raw data (file contents, grep output, images, PDFs) into the main session MUST be delegated to a sub-agent.**

### What changed:
- **New "Token Efficiency Principle"** replaces the old "5-minute rule" in `delegation-prompt.md`
- **Compressed output format** (`<results><files><answer><next_steps>`) adopted from OmO explore agent — all read-only agents must return structured summaries instead of raw data
- **`useWhen`/`avoidWhen` metadata** added to frontmatter of explore, librarian, oracle, metis, momus agents — enables smarter routing decisions
- **Sub-agent routing metadata section** with per-agent heuristics in delegation prompt
- **Output compression directives** added to MUST DO section of delegation template

## 🌐 Korean → English Translation

All prompt files translated from Korean to English for broader accessibility:

| Category | Files Translated |
|----------|-----------------|
| Agents | delegation-prompt, explore, librarian, oracle, metis, momus, atlas |
| Skills | gemini-look-at, multimodal-analysis, steering-words, web-search, tmux, tmux-agents, opencode-controller, workflow-auto-rescue, workflow-tool-patterns |
| Workflows | start-work, ultrawork |
| Config | categories.json (comments + descriptions), SKILL.md |

**Exception**: `steering-words.md` intentionally retains Korean/Japanese/Chinese keywords as they are multilingual detection targets.

## 📦 OmO Pattern Adoption

Patterns from oh-my-opencode (`explore.ts`, `librarian.ts`) ported:

- **`<results>` structured output** — same format used by OmO explore agent
- **`useWhen`/`avoidWhen` frontmatter** — agent routing hints from OmO `AgentPromptMetadata`
- **Intent analysis before search** — explore agent now analyzes literal vs actual need before searching
- **Parallel execution requirement** — explore agent must launch 3+ tools simultaneously

## 📁 Files Changed

- `skills/delegation-prompt.md` — Complete rewrite with token efficiency rules
- `agents/{explore,librarian,oracle,metis,momus,atlas}.md` — useWhen/avoidWhen + results format + English
- `config/categories.json` — English descriptions, expanded quick category
- `skills/{gemini-look-at,multimodal-analysis,steering-words,web-search,tmux,tmux-agents,opencode-controller,workflow-auto-rescue,workflow-tool-patterns}.md` — English translation
- `workflows/{start-work,ultrawork}.md` — English translation
- `SKILL.md` — English skill descriptions
- `plugin/` — All changes synced to plugin directory

## ⚠️ Breaking Changes

None — this is prompt-level only. No changes to plugin source code, dist, or bin.

## Testing

- [x] All files written and synced to `plugin/` mirror
- [x] Intentional Korean preserved in steering-words.md
- [x] Git diff verified: 32 files, 1662 insertions, 1437 deletions