### PR TITLE
feat: migrate to api.on() typed hooks for before_prompt_build

### DIFF
--- a/plugin/src/commands/persona-commands.ts
+++ b/plugin/src/commands/persona-commands.ts
@@ -1,7 +1,6 @@
 import { OmocPluginApi } from '../types.js';
 import { getActivePersona, setActivePersona, resetPersonaState } from '../utils/persona-state.js';
 import { resolvePersonaId, listPersonas, DEFAULT_PERSONA_ID } from '../agents/persona-prompts.js';
-import { resetPersonaInjectorState } from '../hooks/persona-injector.js';
 
 function getDisplayName(personaId: string): string {
   const persona = listPersonas().find((p) => p.id === personaId);
@@ -20,7 +19,6 @@ export function registerPersonaCommands(api: OmocPluginApi) {
 
       if (!args) {
         const previousId = getActivePersona();
-        resetPersonaInjectorState();
         setActivePersona(DEFAULT_PERSONA_ID);
         const name = getDisplayName(DEFAULT_PERSONA_ID);
 
@@ -38,7 +36,6 @@ export function registerPersonaCommands(api: OmocPluginApi) {
         const wasActive = getActivePersona();
         const wasName = wasActive ? getDisplayName(wasActive) : null;
         resetPersonaState();
-        resetPersonaInjectorState();
         return {
           text: wasName
             ? `# OmOC Mode: OFF\n\nPersona **${wasName}** deactivated. Applied immediately — your next message will use default behavior.`
@@ -79,7 +76,6 @@ export function registerPersonaCommands(api: OmocPluginApi) {
       }
 
       const previousId = getActivePersona();
-      resetPersonaInjectorState();
       setActivePersona(resolvedId);
       const displayName = getDisplayName(resolvedId);
       const switched = listPersonas().find((p) => p.id === resolvedId);

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -124,4 +124,30 @@ export interface OmocPluginApi {
   registerService: (config: ServiceRegistration) => void;
   registerGatewayMethod: (name: string, handler: () => unknown) => void;
   registerCli: (registrar: (ctx: { program: unknown; config: unknown; workspaceDir?: string; logger: OmocPluginApi['logger'] }) => void | Promise<void>, opts?: { commands?: string[] }) => void;
+  on: <TEvent = unknown, TResult = unknown>(
+    hookName: string,
+    handler: (event: TEvent, ctx: TypedHookContext) => TResult | Promise<TResult> | void,
+    opts?: { priority?: number }
+  ) => void;
+}
+
+// Typed hook context provided by OpenClaw hookRunner to api.on() handlers
+export interface TypedHookContext {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  workspaceDir?: string;
+  messageProvider?: unknown;
+}
+
+// Result shape for before_prompt_build / before_agent_start hooks
+export interface BeforePromptBuildResult {
+  systemPrompt?: string;
+  prependContext?: string;
+}
+
+// Event shape for before_prompt_build / before_agent_start hooks
+export interface BeforePromptBuildEvent {
+  prompt?: string;
+  messages?: unknown[];
 }


### PR DESCRIPTION
## Problem

`api.registerHook("before_prompt_build", ...)` registers handlers into the **internal hook system** (`registerInternalHook`), but OpenClaw core only triggers `before_prompt_build` via the **hookRunner** (typed hook system). This means:

- **context-injector** was registered but **never executed** ❌
- **persona-injector** used `agent:bootstrap` + `contextCollector` → relied on context-injector → **also broken** ❌

**Evidence from gateway logs:**
- `[hooks] running before_agent_start (1 handlers, sequential)` — typed hooks work ✅
- `before_prompt_build` — only "registered" log, no "running" log ❌

## Solution

Switch both hooks to `api.on()` (typed hook system):

### persona-injector
- `api.registerHook("agent:bootstrap")` → `api.on("before_prompt_build")`
- Auto-detects persona from `ctx.agentId` (hookCtx provided by OpenClaw)
- Manual `/omoc` command takes priority over auto-detection
- Returns `{ prependContext }` directly (no contextCollector dependency)
- Priority: 100 (highest)

### context-injector
- `api.registerHook("before_prompt_build")` → `api.on("before_prompt_build")`
- Uses `ctx.agentId` from typed hook context instead of `event.agentId`
- Returns `{ prependContext }` instead of mutating event
- Priority: 50 (after persona)

### types.ts
- Added `api.on()` method to `OmocPluginApi`
- Added `TypedHookContext`, `BeforePromptBuildEvent`, `BeforePromptBuildResult` interfaces

## OpenClaw Hook Systems (for reference)

| API | System | Triggered by |
|---|---|---|
| `api.registerHook(event, handler)` | Internal hooks (`registerInternalHook`) | `triggerInternalHook()` |
| `api.on(hookName, handler)` | Typed hooks (`registry.typedHooks`) | `hookRunner.runBeforePromptBuild()` |

`before_prompt_build` is **only triggered by hookRunner** → must use `api.on()`.

## Tests

- Build ✅
- 182 tests passed ✅ (7 test files)
- All context-injector and persona-injector tests updated for new `api.on()` API