### PR TITLE
feat(plugin): granular setup options - MCP toggles, todo enforcer, planner guard, tier split (v0.13.4)

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happycastle/oh-my-openclaw",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Oh-My-OpenClaw plugin — multi-agent orchestration, todo enforcer, ralph loop, and custom tools for OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/src/agents/agent-ids.ts
+++ b/plugin/src/agents/agent-ids.ts
@@ -32,9 +32,9 @@ export const AGENT_MD_MAP: Record<string, string> = {
 };
 
 /** Maps agent ID to model tier for provider preset selection */
-export const AGENT_TIER_MAP: Record<string, 'strategic' | 'reasoning' | 'analysis' | 'worker' | 'deep-worker' | 'search' | 'research' | 'visual'> = {
-  omoc_prometheus: 'strategic',
-  omoc_atlas: 'strategic',
+export const AGENT_TIER_MAP: Record<string, 'planner' | 'orchestrator' | 'reasoning' | 'analysis' | 'worker' | 'deep-worker' | 'search' | 'research' | 'visual'> = {
+  omoc_prometheus: 'planner',
+  omoc_atlas: 'orchestrator',
   omoc_oracle: 'reasoning',
   omoc_metis: 'analysis',
   omoc_momus: 'analysis',

--- a/plugin/src/cli/model-presets.ts
+++ b/plugin/src/cli/model-presets.ts
@@ -1,6 +1,6 @@
 import { AGENT_TIER_MAP } from '../agents/agent-ids.js';
 
-export type ModelTier = 'strategic' | 'reasoning' | 'analysis' | 'worker' | 'deep-worker' | 'search' | 'research' | 'visual';
+export type ModelTier = 'planner' | 'orchestrator' | 'reasoning' | 'analysis' | 'worker' | 'deep-worker' | 'search' | 'research' | 'visual';
 
 export type ModelConfig = {
   primary: string;
@@ -11,7 +11,8 @@ export type ProviderPreset = Record<ModelTier, ModelConfig>;
 
 export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
   anthropic: {
-    strategic: { primary: 'anthropic/claude-opus-4-6', fallbacks: ['openai/gpt-5.3-codex'] },
+    planner: { primary: 'anthropic/claude-opus-4-6', fallbacks: ['openai/gpt-5.3-codex'] },
+    orchestrator: { primary: 'anthropic/claude-sonnet-4-6', fallbacks: ['openai/gpt-4.1'] },
     reasoning: { primary: 'anthropic/claude-opus-4-6', fallbacks: ['openai/gpt-5.3-codex'] },
     analysis: { primary: 'anthropic/claude-sonnet-4-6', fallbacks: ['openai/gpt-4.1'] },
     worker: { primary: 'anthropic/claude-opus-4-6', fallbacks: ['openai/gpt-5.3-codex'] },
@@ -21,7 +22,8 @@ export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
     visual: { primary: 'google/gemini-3.1-pro', fallbacks: ['anthropic/claude-sonnet-4-6'] },
   },
   openai: {
-    strategic: { primary: 'openai/gpt-5.3-codex', fallbacks: ['anthropic/claude-opus-4-6'] },
+    planner: { primary: 'openai/gpt-5.3-codex', fallbacks: ['anthropic/claude-opus-4-6'] },
+    orchestrator: { primary: 'openai/gpt-4.1', fallbacks: ['anthropic/claude-sonnet-4-6'] },
     reasoning: { primary: 'openai/gpt-5.3-codex', fallbacks: ['anthropic/claude-opus-4-6'] },
     analysis: { primary: 'openai/gpt-4.1', fallbacks: ['anthropic/claude-sonnet-4-6'] },
     worker: { primary: 'openai/gpt-5.3-codex', fallbacks: ['anthropic/claude-opus-4-6'] },
@@ -31,7 +33,8 @@ export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
     visual: { primary: 'google/gemini-3.1-pro', fallbacks: ['openai/gpt-4.1'] },
   },
   google: {
-    strategic: { primary: 'google/gemini-3.1-pro', fallbacks: ['anthropic/claude-opus-4-6'] },
+    planner: { primary: 'google/gemini-3.1-pro', fallbacks: ['anthropic/claude-opus-4-6'] },
+    orchestrator: { primary: 'google/gemini-3-flash', fallbacks: ['anthropic/claude-sonnet-4-6'] },
     reasoning: { primary: 'google/gemini-3.1-pro', fallbacks: ['anthropic/claude-opus-4-6'] },
     analysis: { primary: 'google/gemini-3-flash', fallbacks: ['anthropic/claude-sonnet-4-6'] },
     worker: { primary: 'google/gemini-3.1-pro', fallbacks: ['anthropic/claude-opus-4-6'] },
@@ -51,7 +54,7 @@ export const PROVIDER_LABELS: Record<string, string> = {
   custom: 'Custom (enter model IDs manually)',
 };
 
-export const MODEL_TIERS: ModelTier[] = ['strategic', 'reasoning', 'analysis', 'worker', 'deep-worker', 'search', 'research', 'visual'];
+export const MODEL_TIERS: ModelTier[] = ['planner', 'orchestrator', 'reasoning', 'analysis', 'worker', 'deep-worker', 'search', 'research', 'visual'];
 
 export function buildCustomPreset(tierModels: Record<ModelTier, string>): ProviderPreset {
   const preset: Partial<ProviderPreset> = {};

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -4,6 +4,7 @@ export const TOOL_PREFIX = 'omoc_';
 export const ABSOLUTE_MAX_RALPH_ITERATIONS = 100;
 export const LOG_PREFIX = '[omoc]';
 export const READ_ONLY_DENY = ['write', 'edit', 'apply_patch', 'sessions_spawn'];
+export const PLANNER_DENY = ['write', 'edit', 'apply_patch'];
 
 // Category definitions
 export const CATEGORIES = [


### PR DESCRIPTION
## Summary

Extends the `omoc-setup` CLI wizard with granular configuration options for MCP servers, plugin features, and model tier separation.

### Changes

- **MCP server toggles**: Split servers into core (exa, context7, grep_app - always included) and optional (web-search-prime, web-reader, zread - user-toggleable per-server Y/n)
- **Todo enforcer toggle**: Enable/disable via interactive wizard, writes `pluginSettings["oh-my-openclaw"].todo_enforcer_enabled` to config
- **Planner guard**: Restricts prometheus (planner only) from editing code via `tools.deny = ["write", "edit", "apply_patch"]` - atlas (orchestrator) is unaffected
- **Tier split**: `strategic` tier split into separate `planner` (expensive: opus/gpt-5.3-codex/gemini-3.1-pro) and `orchestrator` (cheap: sonnet/gpt-4.1/gemini-3-flash) - 9 tiers total
- **4-step wizard**: Provider > Model preview > MCP servers > Plugin features
- **Version bump**: 0.13.3 to 0.13.4

### Files Modified

| File | Change |
|------|--------|
| `plugin/src/constants.ts` | Added `PLANNER_DENY` |
| `plugin/src/cli/mcporter-setup.ts` | Split `CORE_MCP_SERVERS` / `OPTIONAL_MCP_SERVERS`, `excludeServers` support |
| `plugin/src/cli/setup.ts` | 4-step wizard, `applyPlannerGuard()`, todo enforcer settings |
| `plugin/src/cli/model-presets.ts` | 9-tier system (planner/orchestrator split) |
| `plugin/src/agents/agent-ids.ts` | `omoc_prometheus: planner`, `omoc_atlas: orchestrator` |
| `plugin/src/__tests__/agents-cli.test.ts` | 17 new tests (230 total) |
| `plugin/package.json` | 0.13.3 to 0.13.4 |

### Verification

- TypeScript typecheck: clean
- Tests: 230/230 passing

> **Note**: Includes the mcporter setup base from feat/mcporter-setup (PR #10) since exp does not have it yet.