### PR TITLE
fix: align ServiceRegistration with OpenClaw plugin SDK

### DIFF
--- a/plugin/src/services/ralph-loop.ts
+++ b/plugin/src/services/ralph-loop.ts
@@ -79,8 +79,6 @@ export function registerRalphLoop(api: OmocPluginApi): void {
 
   api.registerService({
     id: 'omoc-ralph-loop',
-    name: 'Ralph Loop Service',
-    description: 'Self-referential completion mechanism with configurable iterations',
     start: async () => {
       await loadStateFromFile();
     },

--- a/plugin/src/services/webhook-bridge.ts
+++ b/plugin/src/services/webhook-bridge.ts
@@ -116,8 +116,6 @@ export function registerWebhookBridge(api: OmocPluginApi): void {
 
   api.registerService({
     id: 'omoc-webhook-bridge',
-    name: 'Webhook Bridge Service',
-    description: 'Proactive agent messaging via Gateway webhook hooks',
     start: async () => {
       if (!config.webhook_bridge_enabled) {
         api.logger.info(`${LOG_PREFIX} Webhook bridge disabled (set webhook_bridge_enabled: true to enable)`);

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -76,12 +76,22 @@ export interface CommandRegistration<TCtx = { args?: string }> {
   handler: (ctx: TCtx) => { text: string } | Promise<{ text: string }>;
 }
 
+export interface ServiceContext {
+  config: unknown;
+  workspaceDir?: string;
+  stateDir: string;
+  logger: {
+    info: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+    debug?: (message: string) => void;
+  };
+}
+
 export interface ServiceRegistration {
   id: string;
-  name: string;
-  description?: string;
-  start?: () => Promise<void>;
-  stop?: () => Promise<void>;
+  start: (ctx: ServiceContext) => void | Promise<void>;
+  stop?: (ctx: ServiceContext) => void | Promise<void>;
 }
 
 // OmocPluginApi interface


### PR DESCRIPTION
## Summary

- **Root cause**: `ServiceRegistration` type did not match OpenClaw actual `OpenClawPluginService` — `start` was optional and took no params, while OpenClaw `startPluginServices()` calls `service.start(ctx)` with a required `ServiceContext`
- **Fix**: Aligned type to match SDK — `start` is now required with `(ctx: ServiceContext)` signature, removed non-SDK fields (`name`, `description`)
- **Impact**: Webhook bridge timer and ralph-loop state loading should now auto-start via OpenClaw service lifecycle

## Evidence

From OpenClaw source (`src/plugins/services.ts`): `startPluginServices` iterates all registered services and calls `await service.start(serviceContext)`.

From OpenClaw source (`src/plugins/types.ts`): `OpenClawPluginService.start` is required and accepts `OpenClawPluginServiceContext`.

Reference: `extensions/acpx/src/service.ts` — official ACPX runtime plugin uses same pattern.

## Changes

- `plugin/src/types.ts` — Added `ServiceContext` interface, fixed `ServiceRegistration` to match SDK
- `plugin/src/services/webhook-bridge.ts` — Removed non-SDK `name`/`description` fields
- `plugin/src/services/ralph-loop.ts` — Removed non-SDK `name`/`description` fields

## Verification

- 366/366 tests pass
- Typecheck clean
- Production verification needed after merge