### PR TITLE
feat: anti-hallucination guardrail + subagent wake-on-announce

### DIFF
--- a/plugin/src/hooks/guardrail-injector.ts
+++ b/plugin/src/hooks/guardrail-injector.ts
@@ -1,0 +1,44 @@
+import { OmocPluginApi, TypedHookContext, BeforePromptBuildEvent, BeforePromptBuildResult } from '../types.js';
+import { LOG_PREFIX } from '../constants.js';
+
+const GUARDRAIL_RULES = `
+<anti-hallucination-guardrails>
+## Anti-Hallucination Rules (MANDATORY)
+
+These rules are NON-NEGOTIABLE. Violating them is a critical failure.
+
+### Rule 1: No Fake Tool Calls
+- If you say "I read the file", "I checked the code", "I confirmed in the source", or similar — there MUST be a corresponding \`read\`, \`exec\`, \`grep\`, or equivalent tool call in THE SAME turn.
+- If you did NOT make a tool call, you MUST say: "I haven't verified this directly — this is based on my prior knowledge/context."
+- Phrases that REQUIRE a preceding tool call: "확인했다", "읽었다", "봤다", "코드에서", "소스를 보면", "파일을 열어보니", "checked", "verified", "confirmed", "read the file", "looked at the code"
+
+### Rule 2: No Fabricated Results
+- Never invent file contents, command outputs, or API responses.
+- If you're unsure what a file contains, READ IT. Don't guess.
+- If a tool call fails, report the failure — don't make up what the result "would have been."
+
+### Rule 3: Distinguish Memory from Verification
+- Information from previous sessions or context = "이전 세션 기억 기반으로는..." or "Based on prior context..."
+- Information from THIS session's tool calls = state it directly
+- NEVER present memory/context as if you just verified it with a tool call.
+
+### Rule 4: Sub-agent Delegation Honesty
+- If asked to delegate to a sub-agent, you MUST actually call \`sessions_spawn\` or \`omoc_delegate\`.
+- Saying "서브에이전트 호출 완료" without a tool call = CRITICAL VIOLATION.
+- If the spawn fails, report the failure honestly.
+</anti-hallucination-guardrails>
+`.trim();
+
+export function registerGuardrailInjector(api: OmocPluginApi): void {
+  api.on<BeforePromptBuildEvent, BeforePromptBuildResult>(
+    'before_prompt_build',
+    (_event: BeforePromptBuildEvent, _ctx: TypedHookContext): BeforePromptBuildResult | void => {
+      api.logger.info(`${LOG_PREFIX} Guardrail rules injected via before_prompt_build`);
+
+      return {
+        prependContext: GUARDRAIL_RULES,
+      };
+    },
+    { priority: 90 } // Between persona (100) and context-injector (50)
+  );
+}

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -18,6 +18,7 @@ import { registerRalphCommands } from './commands/ralph-commands.js';
 import { registerStatusCommands } from './commands/status-commands.js';
 import { registerPersonaCommands } from './commands/persona-commands.js';
 import { registerContextInjector } from './hooks/context-injector.js';
+import { registerGuardrailInjector } from './hooks/guardrail-injector.js';
 import { registerSessionSync } from './hooks/session-sync.js';
 import { registerSpawnGuard } from './hooks/spawn-guard.js';
 import { registerKeywordDetector } from './hooks/keyword-detector/hook.js';
@@ -110,6 +111,12 @@ export default function register(api: OmocPluginApi) {
     registerContextInjector(guarded);
     registry.hooks.push('context-injector');
     api.logger.info(`[${PLUGIN_ID}] Context injector hook registered (before_prompt_build)`);
+  });
+
+  safeRegister(api, 'guardrail-injector', 'hook', () => {
+    registerGuardrailInjector(guarded);
+    registry.hooks.push('guardrail-injector');
+    api.logger.info(`[${PLUGIN_ID}] Guardrail injector hook registered (before_prompt_build, priority 90)`);
   });
 
   safeRegister(api, 'session-sync', 'hook', () => {


### PR DESCRIPTION
## What

Adds two features to improve agent reliability:

### 1. Anti-Hallucination Guardrail (new hook)
Dedicated `guardrail-injector` hook that injects rules into every agent's system prompt via `before_prompt_build`.

**Rules Injected:**
1. **No Fake Tool Calls** — Can't claim you read/checked/verified code without a preceding tool call
2. **No Fabricated Results** — Never invent file contents or command outputs
3. **Distinguish Memory from Verification** — Clearly mark prior-context vs this-session tool results
4. **Sub-agent Delegation Honesty** — Must actually call `sessions_spawn`/`omoc_delegate` before claiming completion

### 2. Wake-on-Announce (subagent-tracker enhancement)
When a sub-agent announce message is detected, the tracker now sends `hooks/wake` to ensure the main agent processes the result and continues pending work. Previously, announce could arrive after the agent's turn ended, leaving work incomplete.

## Changes

| File | Change |
|------|--------|
| `plugin/src/hooks/guardrail-injector.ts` | New file — standalone `before_prompt_build` hook (priority 90) |
| `plugin/src/index.ts` | Import + registration block for guardrail-injector |
| `plugin/src/hooks/subagent-tracker.ts` | Added `callHooksWake()` on announce detection |

## Design

- Guardrail injector: priority 90 (between persona at 100 and context-injector at 50)
- Wake-on-announce: only fires when `webhook_bridge_enabled` is true
- Both features are always-on (no config toggle — safety guardrails shouldn't be optional)

## Tests

- Build: `tsc` ✅
- Tests: 366/366 passed ✅
- No test changes needed