### PR TITLE
feat: add /todos command and todo completion notification

### DIFF
--- a/plugin/src/commands/todo-commands.ts
+++ b/plugin/src/commands/todo-commands.ts
@@ -1,0 +1,68 @@
+import { OmocPluginApi } from '../types.js';
+import { TodoItem, TodoStatus, _sessions } from '../tools/todo/store.js';
+
+const STATUS_EMOJI: Record<TodoStatus, string> = {
+  pending: '⏳',
+  in_progress: '🔄',
+  completed: '✅',
+  cancelled: '❌',
+};
+
+function formatTodoList(todos: ReadonlyArray<TodoItem>): string {
+  if (todos.length === 0) {
+    return '📋 No todos found.';
+  }
+
+  const lines: string[] = ['# 📋 Todo List\n'];
+
+  // Status summary
+  const statusOrder: TodoStatus[] = ['in_progress', 'pending', 'completed', 'cancelled'];
+  const counts: Partial<Record<TodoStatus, number>> = {};
+
+  for (const todo of todos) {
+    counts[todo.status] = (counts[todo.status] ?? 0) + 1;
+  }
+
+  const summaryParts: string[] = [];
+  for (const status of statusOrder) {
+    const count = counts[status];
+    if (count && count > 0) {
+      summaryParts.push(`${STATUS_EMOJI[status]} ${status}: ${count}`);
+    }
+  }
+  lines.push(summaryParts.join(' | '));
+  lines.push('');
+
+  // List each todo
+  for (const todo of todos) {
+    const emoji = STATUS_EMOJI[todo.status] ?? '❓';
+    const priority = todo.priority !== 'medium' ? ` [${todo.priority}]` : '';
+    lines.push(`${emoji}${priority} **${todo.id}**: ${todo.content}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Collect todos from ALL session stores.
+ * Command handlers don't receive session context, so we aggregate
+ * across every store to give the user a complete view.
+ */
+function collectAllTodos(): TodoItem[] {
+  const all: TodoItem[] = [];
+  for (const store of _sessions.values()) {
+    all.push(...store.todos);
+  }
+  return all;
+}
+
+export function registerTodoCommands(api: OmocPluginApi): void {
+  api.registerCommand({
+    name: 'todos',
+    description: 'Show current todo list (auto-reply, no AI invocation)',
+    handler: () => {
+      const todos = collectAllTodos();
+      return { text: formatTodoList(todos) };
+    },
+  });
+}

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -17,6 +17,7 @@ import { registerWebSearchTool } from './tools/web-search.js';
 import { registerRalphCommands } from './commands/ralph-commands.js';
 import { registerStatusCommands } from './commands/status-commands.js';
 import { registerPersonaCommands } from './commands/persona-commands.js';
+import { registerTodoCommands } from './commands/todo-commands.js';
 import { registerContextInjector } from './hooks/context-injector.js';
 import { registerGuardrailInjector } from './hooks/guardrail-injector.js';
 import { registerSessionSync } from './hooks/session-sync.js';
@@ -215,6 +216,12 @@ export default function register(api: OmocPluginApi) {
     registerStatusCommands(api);
     registry.commands.push('omoc_health', 'omoc_config');
     api.logger.info(`[${PLUGIN_ID}] Status commands registered (omoc_health, omoc_config)`);
+  });
+
+  safeRegister(api, 'todo-commands', 'command', () => {
+    registerTodoCommands(api);
+    registry.commands.push('todos');
+    api.logger.info(`[${PLUGIN_ID}] Todo commands registered (/todos)`);
   });
 
   initPersonaState(api);

--- a/plugin/src/tools/todo/todo-update.ts
+++ b/plugin/src/tools/todo/todo-update.ts
@@ -59,7 +59,13 @@ export function registerTodoUpdateTool(api: OmocPluginApi): void {
 
       if (!updated) return toolResponse(JSON.stringify({ error: 'todo_not_found', id }));
 
-      return toolResponse(JSON.stringify({ todo: updated }, null, 2));
+      // Include completion notice when status changes to completed
+      const result: Record<string, unknown> = { todo: updated };
+      if (params.status === 'completed') {
+        result.notice = `✅ Todo ${updated.id} completed: ${updated.content}`;
+      }
+
+      return toolResponse(JSON.stringify(result, null, 2));
     },
   });
 }


### PR DESCRIPTION
## Summary

Two new features for user-facing todo management:

### 1. `/todos` Command
A new slash command that shows the current todo list directly in Telegram (auto-reply, no AI invocation).

**Output format:**
```
# 📋 Todo List

🔄 in_progress: 1 | ⏳ pending: 2 | ✅ completed: 3

🔄 **todo-1**: Implement feature X
⏳ [high] **todo-2**: Review PR #28
✅ **todo-3**: Fix webhook bug
```

- Status emojis: ⏳ pending, 🔄 in_progress, ✅ completed, ❌ cancelled
- Priority shown only when not medium (default)
- Shows "📋 No todos found." when empty

### 2. Todo Completion Notice
When `omoc_todo_update` sets status to `completed`, the tool response now includes a `notice` field:
```json
{
  "todo": { ... },
  "notice": "✅ Todo todo-3 completed: Fix webhook bug"
}
```
The agent sees this notice and can relay it to the user.

## Files Changed
| File | Change |
|---|---|
| `src/commands/todo-commands.ts` | **New** — `/todos` command with emoji formatting |
| `src/tools/todo/todo-update.ts` | Add `notice` field on completion |
| `src/index.ts` | Register `todo-commands` via `safeRegister` |

## Testing
- `npm run build` ✅
- `npm run test` — 366/366 tests pass ✅