### PR TITLE
fix: revert to callHooksWake — hooks/agent creates new isolated sessions

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@happycastle/oh-my-openclaw",
-  "version": "0.8.4",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@happycastle/oh-my-openclaw",
-      "version": "0.8.4",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happycastle/oh-my-openclaw",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Oh-My-OpenClaw plugin — multi-agent orchestration, todo enforcer, ralph loop, and custom tools for OpenClaw",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Root Cause Analysis

`/hooks/agent` always creates a **new isolated session** (`sessionTarget: 'isolated'` + `runCronIsolatedAgentTurn`) instead of routing to the existing main session. Even with `sessionKey='agent:omoc_prometheus:main'`, OpenClaw creates `agent:omoc_prometheus:hook:<uuid>` — a completely new session.

### What was wrong with PR #31

The change from `callHooksWake` → `callHooksAgent` was incorrect:
- `/hooks/agent` creates new isolated sessions for every call
- This caused ~20+ orphaned `hook:` sessions being created
- The main agent never got woken up because the wake message went to a new session

### Fix

Revert back to `callHooksWake` which:
- Directly injects system event into main session via `enqueueSystemEvent()`
- Triggers `requestHeartbeatNow()` with mode: 'now'
- Main session key resolved via `resolveMainSessionKeyFromConfig()`

### Testing

Both endpoints tested:
- `POST /hooks/agent` → 202 (creates new isolated session ❌)
- `POST /hooks/wake` → 200 (injects into main session ✅)
- TypeScript: clean build
- Tests: 366/366 passed

### Changes
- `subagent-tracker.ts`: `callHooksAgent` → `callHooksWake` (both handlers)
- Simplified call signatures (`callHooksWake` takes `text, config, logger`)
- Removed unnecessary options (`name`, `deliver`, `sessionKey`) since `/hooks/wake` always targets main session