### PR TITLE
fix: isolate todo store per session key

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happycastle/oh-my-openclaw",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Oh-My-OpenClaw plugin \u2014 multi-agent orchestration, todo enforcer, ralph loop, and custom tools for OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/plugin/src/hooks/todo-reminder.ts
+++ b/plugin/src/hooks/todo-reminder.ts
@@ -1,6 +1,7 @@
 import { OmocPluginApi, TypedHookContext } from '../types.js';
 import { TOOL_PREFIX, LOG_PREFIX } from '../constants.js';
 import { getIncompleteTodos, resetStore } from '../tools/todo/store.js';
+import { setCurrentSessionKey } from '../tools/todo/session-key.js';
 import { getConfig } from '../utils/config.js';
 import { callHooksWake } from '../utils/webhook-client.js';
 
@@ -147,6 +148,7 @@ export function registerSessionCleanup(api: OmocPluginApi): void {
       const sessionKey = ctx.sessionKey ?? ctx.sessionId ?? event.sessionId;
       if (!sessionKey) return;
 
+      setCurrentSessionKey(sessionKey);
       clearSession(sessionKey, api, 'new session');
     },
     { priority: 190 },
@@ -158,6 +160,7 @@ export function registerSessionCleanup(api: OmocPluginApi): void {
       const sessionKey = ctx.sessionId ?? event.sessionId;
       if (!sessionKey) return;
 
+      setCurrentSessionKey(undefined);
       clearSession(sessionKey, api, 'session_end');
     },
     { priority: 50 },

--- a/plugin/src/tools/todo/session-key.ts
+++ b/plugin/src/tools/todo/session-key.ts
@@ -1,40 +1,19 @@
-/**
- * Session key management for todo tools.
- *
- * ## Concurrency Model
- *
- * This module uses a singleton `currentSessionKey` for capturing the session key
- * from the `session_start` hook. While AsyncLocalStorage would provide better
- * isolation for truly concurrent sessions, OpenClaw's execution model makes
- * this unnecessary in practice:
- *
- * 1. OpenClaw processes one agent turn at a time per session
- * 2. Tool calls within a single agent turn are sequential (not parallel)
- * 3. Session lifecycle hooks (`session_start`, `session_end`) fire synchronously
- *    in the session context before/after agent turns
- *
- * This means there's no actual concurrent access to `currentSessionKey` within
- * a single session. The singleton pattern is safe because:
- * - Each session has its own isolated execution context
- * - Tool executions are sequential within a turn
- * - The safety net `tool_result_persist` hook validates sessionKey correctness
- *
- * ## Safety Net
- *
- * As an additional safeguard, the `todo-reminder` hook registers a
- * `tool_result_persist` hook that validates and corrects the sessionKey
- * for todo tools after each tool execution.
- */
+import { AsyncLocalStorage } from 'node:async_hooks';
 
-// Module-level state to capture session key from session_start hook
+const sessionStore = new AsyncLocalStorage<string>();
+
 let currentSessionKey: string | undefined;
 
-export function setCurrentSessionKey(key: string | undefined): void {
-  currentSessionKey = key;
+export function runWithSessionKey<T>(sessionKey: string, fn: () => T): T {
+  return sessionStore.run(sessionKey, fn);
 }
 
 export function getCurrentSessionKey(): string | undefined {
-  return currentSessionKey;
+  return sessionStore.getStore() ?? currentSessionKey;
+}
+
+export function setCurrentSessionKey(key: string | undefined): void {
+  currentSessionKey = key;
 }
 
 export function clearCurrentSessionKey(): void {
@@ -51,10 +30,8 @@ export function extractSessionKey(options?: unknown): string | undefined {
 }
 
 export function resolveSessionKey(options?: unknown): string | undefined {
-  // First try extracting from options (for future OpenClaw API changes)
   const extracted = extractSessionKey(options);
   if (extracted !== undefined) return extracted;
 
-  // Fall back to captured session key from session_start hook
   return getCurrentSessionKey();
 }

--- a/plugin/src/tools/todo/session-key.ts
+++ b/plugin/src/tools/todo/session-key.ts
@@ -1,3 +1,31 @@
+/**
+ * Session key management for todo tools.
+ *
+ * ## Concurrency Model
+ *
+ * This module uses a singleton `currentSessionKey` for capturing the session key
+ * from the `session_start` hook. While AsyncLocalStorage would provide better
+ * isolation for truly concurrent sessions, OpenClaw's execution model makes
+ * this unnecessary in practice:
+ *
+ * 1. OpenClaw processes one agent turn at a time per session
+ * 2. Tool calls within a single agent turn are sequential (not parallel)
+ * 3. Session lifecycle hooks (`session_start`, `session_end`) fire synchronously
+ *    in the session context before/after agent turns
+ *
+ * This means there's no actual concurrent access to `currentSessionKey` within
+ * a single session. The singleton pattern is safe because:
+ * - Each session has its own isolated execution context
+ * - Tool executions are sequential within a turn
+ * - The safety net `tool_result_persist` hook validates sessionKey correctness
+ *
+ * ## Safety Net
+ *
+ * As an additional safeguard, the `todo-reminder` hook registers a
+ * `tool_result_persist` hook that validates and corrects the sessionKey
+ * for todo tools after each tool execution.
+ */
+
 // Module-level state to capture session key from session_start hook
 let currentSessionKey: string | undefined;
 
@@ -7,6 +35,10 @@ export function setCurrentSessionKey(key: string | undefined): void {
 
 export function getCurrentSessionKey(): string | undefined {
   return currentSessionKey;
+}
+
+export function clearCurrentSessionKey(): void {
+  currentSessionKey = undefined;
 }
 
 export function extractSessionKey(options?: unknown): string | undefined {

--- a/plugin/src/tools/todo/session-key.ts
+++ b/plugin/src/tools/todo/session-key.ts
@@ -1,3 +1,14 @@
+// Module-level state to capture session key from session_start hook
+let currentSessionKey: string | undefined;
+
+export function setCurrentSessionKey(key: string | undefined): void {
+  currentSessionKey = key;
+}
+
+export function getCurrentSessionKey(): string | undefined {
+  return currentSessionKey;
+}
+
 export function extractSessionKey(options?: unknown): string | undefined {
   if (typeof options === 'object' && options !== null) {
     const opts = options as Record<string, unknown>;
@@ -5,4 +16,13 @@ export function extractSessionKey(options?: unknown): string | undefined {
     if (typeof opts.sessionId === 'string') return opts.sessionId;
   }
   return undefined;
+}
+
+export function resolveSessionKey(options?: unknown): string | undefined {
+  // First try extracting from options (for future OpenClaw API changes)
+  const extracted = extractSessionKey(options);
+  if (extracted !== undefined) return extracted;
+
+  // Fall back to captured session key from session_start hook
+  return getCurrentSessionKey();
 }

--- a/plugin/src/tools/todo/todo-create.ts
+++ b/plugin/src/tools/todo/todo-create.ts
@@ -3,7 +3,7 @@ import { OmocPluginApi, ToolResult } from '../../types.js';
 import { toolResponse, toolError } from '../../utils/helpers.js';
 import { TOOL_PREFIX } from '../../constants.js';
 import { createTodo, TodoPriority, TodoStatus } from './store.js';
-import { extractSessionKey } from './session-key.js';
+import { extractSessionKey, resolveSessionKey } from './session-key.js';
 
 const TodoCreateParamsSchema = Type.Object({
   content: Type.String({ description: 'What needs to be done' }),
@@ -41,7 +41,7 @@ export function registerTodoCreateTool(api: OmocPluginApi): void {
       const content = params.content?.trim();
       if (!content) return toolError('content is required');
 
-      const sessionKey = extractSessionKey(options);
+      const sessionKey = resolveSessionKey(options);
       const item = createTodo(content, params.priority, params.status, sessionKey);
       return toolResponse(JSON.stringify({ todo: item }, null, 2));
     },

--- a/plugin/src/tools/todo/todo-list.ts
+++ b/plugin/src/tools/todo/todo-list.ts
@@ -3,7 +3,7 @@ import { OmocPluginApi, ToolResult } from '../../types.js';
 import { toolResponse } from '../../utils/helpers.js';
 import { TOOL_PREFIX } from '../../constants.js';
 import { listTodos, TodoStatus } from './store.js';
-import { extractSessionKey } from './session-key.js';
+import { resolveSessionKey } from './session-key.js';
 
 const TodoListParamsSchema = Type.Object({
   status: Type.Optional(
@@ -30,7 +30,7 @@ export function registerTodoListTool(api: OmocPluginApi): void {
       params: TodoListParams,
       options?: unknown,
     ): Promise<ToolResult> => {
-      const sessionKey = extractSessionKey(options);
+      const sessionKey = resolveSessionKey(options);
       const items = listTodos(params.status, sessionKey);
       return toolResponse(JSON.stringify({ todos: items, count: items.length }, null, 2));
     },

--- a/plugin/src/tools/todo/todo-update.ts
+++ b/plugin/src/tools/todo/todo-update.ts
@@ -3,7 +3,7 @@ import { OmocPluginApi, ToolResult } from '../../types.js';
 import { toolResponse, toolError } from '../../utils/helpers.js';
 import { TOOL_PREFIX } from '../../constants.js';
 import { updateTodo, TodoStatus, TodoPriority } from './store.js';
-import { extractSessionKey } from './session-key.js';
+import { resolveSessionKey } from './session-key.js';
 
 const TodoUpdateParamsSchema = Type.Object({
   id: Type.String({ description: 'Todo ID (e.g. todo-1)' }),
@@ -46,7 +46,7 @@ export function registerTodoUpdateTool(api: OmocPluginApi): void {
         return toolError('At least one of status, priority, or content must be provided');
       }
 
-      const sessionKey = extractSessionKey(options);
+      const sessionKey = resolveSessionKey(options);
       const updated = updateTodo(
         id,
         {


### PR DESCRIPTION
Fixes todo isolation per session key. Previously all sessions shared __default__ bucket because OpenClaw passes AbortSignal as 3rd param to tool execute. Now captures sessionKey from session_start hook and uses it as fallback in tool execute.